### PR TITLE
chore: deprecate toggle field's defaultChecked prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/components/ToggleFields/BasicToggleField/BasicToggleField.stories.tsx
+++ b/src/components/ToggleFields/BasicToggleField/BasicToggleField.stories.tsx
@@ -19,7 +19,6 @@ export const Playground: ComponentStory<typeof BasicToggleField> =
   Template.bind({});
 
 Playground.args = {
-  defaultChecked: false,
   disabled: false,
   readOnly: false,
   required: true,

--- a/src/components/ToggleFields/BasicToggleField/BasicToggleField.tsx
+++ b/src/components/ToggleFields/BasicToggleField/BasicToggleField.tsx
@@ -62,7 +62,6 @@ const BasicToggleField: React.FC<BasicToggleFieldProps> = (props) => {
       onChangeInput={props.onChangeInput}
       required={props.required}
       label={props.label}
-      defaultChecked={props.defaultChecked}
       focusHighlight={true}
       dotColor="bg-instillGrey30"
       checkedDotColor="bg-instillBlue50"

--- a/src/components/ToggleFields/StatefulToggleField/StatefulToggleField.stories.tsx
+++ b/src/components/ToggleFields/StatefulToggleField/StatefulToggleField.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { State } from "../../../types/general";
 import StatefulToggleField from "./StatefulToggleField";
 
@@ -38,7 +38,6 @@ export const Playground: ComponentStory<typeof StatefulToggleField> =
   Template.bind({});
 
 Playground.args = {
-  defaultChecked: false,
   disabled: false,
   readOnly: false,
   required: true,

--- a/src/components/ToggleFields/StatefulToggleField/StatefulToggleField.tsx
+++ b/src/components/ToggleFields/StatefulToggleField/StatefulToggleField.tsx
@@ -72,7 +72,6 @@ const StatefulToggleField: React.FC<StatefulToggleFieldProps> = (props) => {
       onChangeInput={props.onChangeInput}
       required={props.required}
       label={props.label}
-      defaultChecked={props.defaultChecked}
       focusHighlight={true}
       dotColor="bg-instillGrey30"
       checkedDotColor="bg-instillBlue50"

--- a/src/components/ToggleFields/ToggleFieldBase/ToggleFieldBase.stories.tsx
+++ b/src/components/ToggleFields/ToggleFieldBase/ToggleFieldBase.stories.tsx
@@ -24,7 +24,6 @@ export const Playground: ComponentStory<typeof ToggleFieldBase> = Template.bind(
 );
 
 Playground.args = {
-  defaultChecked: false,
   required: true,
   focusHighlight: true,
   onChangeInput: () => undefined,

--- a/src/components/ToggleFields/ToggleFieldBase/ToggleFieldBase.tsx
+++ b/src/components/ToggleFields/ToggleFieldBase/ToggleFieldBase.tsx
@@ -33,9 +33,6 @@ export type ToggleFieldBaseProps = Omit<
   | "errorInputBorderWidth"
   | "errorInputTextColor"
 > & {
-  /** The initial checked state of this toggle field */
-  defaultChecked: boolean;
-
   /** TailwindCSS format - Toggle center's dot color
    * - Please use background-color, e.g. bg-blqck
    */
@@ -112,7 +109,6 @@ const ToggleFieldBase: React.FC<ToggleFieldBaseProps> = ({
   label,
   additionalMessageOnLabel,
   description,
-  defaultChecked,
   disabled,
   readOnly,
   focusHighlight,
@@ -272,7 +268,6 @@ const ToggleFieldBase: React.FC<ToggleFieldBaseProps> = ({
             onBlur={() => {
               setFocus(false);
             }}
-            defaultChecked={defaultChecked}
           />
           <div
             className={cn(


### PR DESCRIPTION
Because

- Toggle field's value and defaultChecked had conflict

This commit

- Deprecate defaultChecked