### PR TITLE
refactor: refactor ProgressMessageBox

### DIFF
--- a/src/components/ProgressMessageBoxs/BasicProgressMessageBox/BasicProgressMessageBox.stories.tsx
+++ b/src/components/ProgressMessageBoxs/BasicProgressMessageBox/BasicProgressMessageBox.stories.tsx
@@ -7,9 +7,7 @@ export default {
 } as ComponentMeta<typeof BasicProgressMessageBox>;
 
 const Template: ComponentStory<typeof BasicProgressMessageBox> = (args) => (
-  <BasicProgressMessageBox {...args}>
-    Testing connection...
-  </BasicProgressMessageBox>
+  <BasicProgressMessageBox {...args} />
 );
 export const Playground: ComponentStory<typeof BasicProgressMessageBox> =
   Template.bind({});
@@ -17,4 +15,5 @@ export const Playground: ComponentStory<typeof BasicProgressMessageBox> =
 Playground.args = {
   status: "progressing",
   width: "w-[300px]",
+  message: "Testing connection...",
 };

--- a/src/components/ProgressMessageBoxs/BasicProgressMessageBox/BasicProgressMessageBox.tsx
+++ b/src/components/ProgressMessageBoxs/BasicProgressMessageBox/BasicProgressMessageBox.tsx
@@ -31,6 +31,7 @@ const BasicProgressMessageBox: React.FC<BasicProgressMessageBoxProps> = (
   return (
     <ProgressMessageBoxBase
       status={props.status}
+      message={props.message}
       width={props.width}
       errorIconColor="fill-instillRed"
       errorIconWidth="w-7"
@@ -50,9 +51,7 @@ const BasicProgressMessageBox: React.FC<BasicProgressMessageBoxProps> = (
       successIndicatorColumnBgColor="bg-instillGreen10"
       processingIndicatorColumnBgColor="bg-instillBlue10"
       errorindicatorColumnBgColor="bg-instillRed10"
-    >
-      {props.children}
-    </ProgressMessageBoxBase>
+    />
   );
 };
 

--- a/src/components/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.stories.tsx
+++ b/src/components/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.stories.tsx
@@ -7,9 +7,7 @@ export default {
 } as ComponentMeta<typeof ProgressMessageBoxBase>;
 
 const Template: ComponentStory<typeof ProgressMessageBoxBase> = (args) => (
-  <ProgressMessageBoxBase {...args}>
-    Testing connection...
-  </ProgressMessageBoxBase>
+  <ProgressMessageBoxBase {...args} />
 );
 export const Playground: ComponentStory<typeof ProgressMessageBoxBase> =
   Template.bind({});
@@ -32,4 +30,5 @@ Playground.args = {
   messageColumnBottomRightBorderRadius: "rounded-br-[1px]",
   messageColumnTopRightBorderRadius: "rounded-tr-[1px]",
   boxBorderRadius: "rounded-[1px]",
+  message: "Testing connection...",
 };

--- a/src/components/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.tsx
+++ b/src/components/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.tsx
@@ -2,9 +2,15 @@ import React from "react";
 import { PixelCheckIcon, PixelCrossIcon } from "../../Icons";
 import NoBgSquareProgress from "../../Progress/NoBgSquareProgress";
 import cn from "clsx";
+import { Nullable } from "../../../types/general";
 
 export type ProgressMessageBoxBaseProps = {
   status: "success" | "error" | "progressing";
+
+  /**
+   *  ProgressMessageBox will return null if the children is null or undefinded
+   */
+  message: Nullable<string>;
 
   /** The width of the whole message box
    * - e.g. w-120
@@ -105,7 +111,6 @@ export type ProgressMessageBoxBaseProps = {
 
 const ProgressMessageBoxBase: React.FC<ProgressMessageBoxBaseProps> = ({
   status,
-  children,
   width,
   errorIconColor,
   errorIconWidth,
@@ -125,8 +130,11 @@ const ProgressMessageBoxBase: React.FC<ProgressMessageBoxBaseProps> = ({
   messageColumnBottomRightBorderRadius,
   messageColumnTopRightBorderRadius,
   boxBorderRadius,
+  message,
 }) => {
   const statusIcon = React.useMemo(() => {
+    if (!message) return null;
+
     switch (status) {
       case "error":
         return (
@@ -190,7 +198,7 @@ const ProgressMessageBoxBase: React.FC<ProgressMessageBoxBaseProps> = ({
         )}
       >
         <p className="instill-text-h3 text-instillGrey90 break-normal">
-          {children}
+          {message}
         </p>
       </div>
     </div>


### PR DESCRIPTION
Because

- Progress message box should return null if the message is null or undefinded

This commit

- Refactor ProgressMessageBox
