### PR TITLE
feat: make progress message box status nullable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/components/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.tsx
+++ b/src/components/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.tsx
@@ -5,7 +5,7 @@ import cn from "clsx";
 import { Nullable } from "../../../types/general";
 
 export type ProgressMessageBoxState = {
-  status: "success" | "error" | "progressing";
+  status: Nullable<"success" | "error" | "progressing">;
   /**
    *  ProgressMessageBox's message
    */
@@ -181,6 +181,8 @@ const ProgressMessageBoxBase: React.FC<ProgressMessageBoxBaseProps> = ({
             color={successIconColor}
           />
         );
+      default:
+        return null;
     }
   }, [state.status]);
 


### PR DESCRIPTION
Because

- Progress message box's status can be nullable

This commit

- Make progress message box status nullable
