### PR TITLE
feat: add utility types for TextFields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/components/TextFields/BasicTextField/BasicTextField.stories.tsx
+++ b/src/components/TextFields/BasicTextField/BasicTextField.stories.tsx
@@ -19,12 +19,9 @@ const Template: ComponentStory<typeof BasicTextField> = (args) => {
       {...args}
       id="text-field-playground"
       label="text-field-playground"
-      additionalMessageOnLabel={null}
       description="this is a description for text field <a href='#'>setup guide</a>"
-      placeholder="hello!"
       value={value}
       onChangeInput={onChnageInput}
-      error={null}
     />
   );
 };

--- a/src/components/TextFields/BasicTextField/BasicTextField.tsx
+++ b/src/components/TextFields/BasicTextField/BasicTextField.tsx
@@ -5,8 +5,13 @@ import {
 } from "../../InputDescriptions";
 import TextFieldBase, { TextFieldBaseProps } from "../TextFieldBase";
 
-export type BasicTextFieldProps = Omit<
-  TextFieldBaseProps,
+export type BasicTextFieldRequiredKeys =
+  | "id"
+  | "value"
+  | "onChangeInput"
+  | "label";
+
+export type BasicTextFieldOmitKeys =
   | "inputHeight"
   | "inputWidth"
   | "focusHighlight"
@@ -55,75 +60,99 @@ export type BasicTextFieldProps = Omit<
   | "errorInputBorderColor"
   | "errorInputBorderWidth"
   | "errorInputBorderStyle"
-  | "errorInputTextColor"
-  | BasicInputDescriptionOmitKeys
+  | "errorInputTextColor";
+
+export type BasicTextFieldConfig = Pick<
+  TextFieldBaseProps,
+  BasicTextFieldOmitKeys
 >;
+
+export const basicTextFieldConfig: BasicTextFieldConfig = {
+  inputHeight: "h-[70px]",
+  inputWidth: "w-full",
+  focusHighlight: true,
+  inputBgColor: "bg-white",
+  inputFontSize: "text-base",
+  inputLineHeight: "leading-[28px]",
+  inputFontWeight: "font-normal",
+  inputTextColor: "text-instillGrey95",
+  bgColor: "bg-white",
+  enableProtectedToggle: false,
+  inputBorderRadius: "rounded-[1px]",
+  inputBorderColor: "border-instillGrey20",
+  inputBorderStyle: "border-solid",
+  inputBorderWidth: "border",
+  inputLabelType: "inset",
+  disabledCursor: "cursor-not-allowed",
+  disabledInputBgColor: "bg-white",
+  disabledInputBorderColor: "border-instillGrey20",
+  disabledInputBorderStyle: "border-dashed",
+  disabledInputBorderWidth: "border",
+  disabledInputTextColor: "text-instillGrey50",
+  readOnlyCursor: "cursor-auto",
+  readOnlyInputBgColor: "bg-white",
+  readOnlyInputBorderColor: "border-instillGrey20",
+  readOnlyInputBorderStyle: "border-solid",
+  readOnlyInputBorderWidth: "border",
+  readOnlyInputTextColor: "text-instillGrey95",
+  placeholderFontFamily: "placeholder:font-sans",
+  placeholderFontSize: "placeholder:text-base",
+  placeholderFontWeight: "placeholder:font-normal",
+  placeholderLineHeight: "placeholder:leading-[28px]",
+  placeholderTextColor: "placeholder:text-instillGrey95",
+  labelFontSize: "text-sm",
+  labelFontWeight: "font-normal",
+  labelTextColor: "text-instillGrey50",
+  labelFontFamily: "font-sans",
+  labelLineHeight: "leading-[18.2px]",
+  labelActivateStyle: "top-1/2 -translate-y-[120%]",
+  labelDeActivateStyle: "top-1/2 -translate-y-1/2",
+  errorInputBgColor: "bg-white",
+  errorLabelFontFamily: "font-sans",
+  errorLabelFontSize: "text-sm",
+  errorLabelFontWeight: "font-normal",
+  errorLabelLineHeight: "leading-[18.2px]",
+  errorLabelTextColor: "text-instillRed",
+  errorInputBorderColor: "border-instillRed",
+  errorInputBorderWidth: "border",
+  errorInputBorderStyle: "border-solid",
+  errorInputTextColor: "text-instillRed",
+};
+
+export type FullBasicTextFieldProps = Omit<
+  TextFieldBaseProps,
+  BasicTextFieldOmitKeys | BasicInputDescriptionOmitKeys
+>;
+
+export type BasicTextFieldRequiredProps = Pick<
+  FullBasicTextFieldProps,
+  BasicTextFieldRequiredKeys
+>;
+
+export type BasicTextFieldOptionalProps = Partial<
+  Omit<FullBasicTextFieldProps, BasicTextFieldRequiredKeys>
+>;
+
+export type BasicTextFieldProps = BasicTextFieldRequiredProps &
+  BasicTextFieldOptionalProps;
 
 const BasicTextField: React.FC<BasicTextFieldProps> = (props) => {
   return (
     <TextFieldBase
       id={props.id}
       value={props.value}
-      additionalMessageOnLabel={props.additionalMessageOnLabel}
-      description={props.description}
-      disabled={props.disabled}
-      type={props.type}
-      required={props.required}
       onChangeInput={props.onChangeInput}
-      error={props.error}
       label={props.label}
-      autoComplete={props.autoComplete}
-      placeholder={props.placeholder}
-      readOnly={props.readOnly}
-      inputHeight="h-[70px]"
-      inputWidth="w-full"
-      focusHighlight={true}
-      inputBgColor="bg-white"
-      inputFontSize="text-base"
-      inputLineHeight="leading-[28px]"
-      inputFontWeight="font-normal"
-      inputTextColor="text-instillGrey95"
-      bgColor="bg-white"
-      enableProtectedToggle={false}
-      inputBorderRadius="rounded-[1px]"
-      inputBorderColor="border-instillGrey20"
-      inputBorderStyle="border-solid"
-      inputBorderWidth="border"
-      inputLabelType="inset"
-      disabledCursor="cursor-not-allowed"
-      disabledInputBgColor="bg-white"
-      disabledInputBorderColor="border-instillGrey20"
-      disabledInputBorderStyle="border-dashed"
-      disabledInputBorderWidth="border"
-      disabledInputTextColor="text-instillGrey50"
-      readOnlyCursor="cursor-auto"
-      readOnlyInputBgColor="bg-white"
-      readOnlyInputBorderColor="border-instillGrey20"
-      readOnlyInputBorderStyle="border-solid"
-      readOnlyInputBorderWidth="border"
-      readOnlyInputTextColor="text-instillGrey95"
-      placeholderFontFamily="placeholder:font-sans"
-      placeholderFontSize="placeholder:text-base"
-      placeholderFontWeight="placeholder:font-normal"
-      placeholderLineHeight="placeholder:leading-[28px]"
-      placeholderTextColor="placeholder:text-instillGrey95"
-      labelFontSize="text-sm"
-      labelFontWeight="font-normal"
-      labelTextColor="text-instillGrey50"
-      labelLineHeight="leading-[18.2px]"
-      labelFontFamily="font-sans"
-      labelActivateStyle="top-1/2 -translate-y-[120%]"
-      labelDeActivateStyle="top-1/2 -translate-y-1/2"
-      errorInputBgColor="bg-white"
-      errorLabelFontFamily="font-sans"
-      errorLabelFontSize="text-sm"
-      errorLabelFontWeight="font-normal"
-      errorLabelLineHeight="leading-[18.2px]"
-      errorLabelTextColor="text-instillRed"
-      errorInputBorderColor="border-instillRed"
-      errorInputBorderWidth="border"
-      errorInputBorderStyle="border-solid"
-      errorInputTextColor="text-instillRed"
+      additionalMessageOnLabel={props.additionalMessageOnLabel ?? null}
+      description={props.description ?? ""}
+      disabled={props.disabled ?? false}
+      type={props.type ?? "text"}
+      required={props.required ?? false}
+      error={props.error ?? null}
+      autoComplete={props.autoComplete ?? "off"}
+      placeholder={props.placeholder ?? ""}
+      readOnly={props.readOnly ?? false}
+      {...basicTextFieldConfig}
       {...basicInputDescriptionConfig}
     />
   );

--- a/src/components/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.stories.tsx
+++ b/src/components/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.stories.tsx
@@ -20,10 +20,8 @@ const Template: ComponentStory<typeof ProtectedBasicTextField> = (args) => {
       id="protected-text-field-playground"
       label="protected-text-field-playground"
       description="this is a description for protected text field <a href='#'>setup guide</a>"
-      placeholder="hello!"
       value={value}
       onChangeInput={onChnageInput}
-      error={null}
     />
   );
 };

--- a/src/components/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.tsx
+++ b/src/components/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.tsx
@@ -5,8 +5,13 @@ import {
 } from "../../InputDescriptions";
 import TextFieldBase, { TextFieldBaseProps } from "../TextFieldBase";
 
-export type ProtectedBasicTextFieldProps = Omit<
-  TextFieldBaseProps,
+export type ProtectedBasicTextFieldRequiredKeys =
+  | "id"
+  | "value"
+  | "onChangeInput"
+  | "label";
+
+export type ProtectedBasicTextFieldOmitKeys =
   | "enableProtectedToggle"
   | "type"
   | "inputHeight"
@@ -57,9 +62,83 @@ export type ProtectedBasicTextFieldProps = Omit<
   | "errorInputBorderWidth"
   | "errorInputBorderStyle"
   | "errorInputTextColor"
-  | "autoComplete"
-  | BasicInputDescriptionOmitKeys
+  | "autoComplete";
+
+export type ProtectedBasicTextFieldConfig = Pick<
+  TextFieldBaseProps,
+  ProtectedBasicTextFieldOmitKeys
 >;
+
+export const protectedBasicTextFieldConfig: ProtectedBasicTextFieldConfig = {
+  focusHighlight: true,
+  enableProtectedToggle: true,
+  type: "password",
+  inputBgColor: "bg-white",
+  inputFontSize: "text-base",
+  inputLineHeight: "leading-[28px]",
+  inputFontWeight: "font-normal",
+  bgColor: "bg-white",
+  inputTextColor: "text-instillGrey95",
+  inputHeight: "h-[70px]",
+  inputWidth: "w-full",
+  inputLabelType: "inset",
+  inputBorderRadius: "rounded-[1px]",
+  inputBorderColor: "border-instillGrey20",
+  inputBorderStyle: "border-solid",
+  inputBorderWidth: "border",
+  disabledCursor: "cursor-not-allowed",
+  disabledInputBgColor: "bg-white",
+  disabledInputBorderColor: "border-instillGrey20",
+  disabledInputBorderStyle: "border-dashed",
+  disabledInputBorderWidth: "border",
+  disabledInputTextColor: "text-instillGrey50",
+  readOnlyCursor: "cursor-auto",
+  readOnlyInputBgColor: "bg-white",
+  readOnlyInputBorderColor: "border-instillGrey20",
+  readOnlyInputBorderStyle: "border-solid",
+  readOnlyInputBorderWidth: "border",
+  readOnlyInputTextColor: "text-instillGrey95",
+  placeholderFontFamily: "placeholder:font-sans",
+  placeholderFontSize: "placeholder:text-base",
+  placeholderFontWeight: "placeholder:font-normal",
+  placeholderLineHeight: "placeholder:leading-[28px]",
+  placeholderTextColor: "placeholder:text-instillGrey95",
+  labelFontSize: "text-sm",
+  labelFontWeight: "font-normal",
+  labelTextColor: "text-instillGrey50",
+  labelLineHeight: "leading-[18.2px]",
+  labelFontFamily: "font-sans",
+  labelActivateStyle: "top-1/2 -translate-y-[120%]",
+  labelDeActivateStyle: "top-1/2 -translate-y-1/2",
+  errorInputBgColor: "bg-white",
+  errorLabelFontFamily: "font-sans",
+  errorLabelFontSize: "text-sm",
+  errorLabelFontWeight: "font-normal",
+  errorLabelLineHeight: "leading-[18.2px]",
+  errorLabelTextColor: "text-instillRed",
+  errorInputBorderColor: "border-instillRed",
+  errorInputBorderWidth: "border",
+  errorInputBorderStyle: "border-solid",
+  errorInputTextColor: "text-instillRed",
+  autoComplete: "off",
+};
+
+export type FullProtectedBasicTextFieldProps = Omit<
+  TextFieldBaseProps,
+  BasicInputDescriptionOmitKeys | ProtectedBasicTextFieldOmitKeys
+>;
+
+export type ProtectedBasicTextFieldRequiredProps = Pick<
+  FullProtectedBasicTextFieldProps,
+  ProtectedBasicTextFieldRequiredKeys
+>;
+
+export type ProtectedBasicTextFieldOptionalProps = Partial<
+  Omit<FullProtectedBasicTextFieldProps, ProtectedBasicTextFieldRequiredKeys>
+>;
+
+export type ProtectedBasicTextFieldProps =
+  ProtectedBasicTextFieldRequiredProps & ProtectedBasicTextFieldOptionalProps;
 
 const ProtectedBasicTextField: React.FC<ProtectedBasicTextFieldProps> = (
   props
@@ -68,66 +147,16 @@ const ProtectedBasicTextField: React.FC<ProtectedBasicTextFieldProps> = (
     <TextFieldBase
       id={props.id}
       value={props.value}
-      additionalMessageOnLabel={props.additionalMessageOnLabel}
-      description={props.description}
-      disabled={props.disabled}
-      required={props.required}
-      onChangeInput={props.onChangeInput}
-      error={props.error}
       label={props.label}
-      autoComplete="off"
-      placeholder={props.placeholder}
-      readOnly={props.readOnly}
-      focusHighlight={true}
-      enableProtectedToggle={true}
-      type="password"
-      inputBgColor="bg-white"
-      inputFontSize="text-base"
-      inputLineHeight="leading-[28px]"
-      inputFontWeight="font-normal"
-      bgColor="bg-white"
-      inputTextColor="text-instillGrey95"
-      inputHeight="h-[70px]"
-      inputWidth="w-full"
-      inputLabelType="inset"
-      inputBorderRadius="rounded-[1px]"
-      inputBorderColor="border-instillGrey20"
-      inputBorderStyle="border-solid"
-      inputBorderWidth="border"
-      disabledCursor="cursor-not-allowed"
-      disabledInputBgColor="bg-white"
-      disabledInputBorderColor="border-instillGrey20"
-      disabledInputBorderStyle="border-dashed"
-      disabledInputBorderWidth="border"
-      disabledInputTextColor="text-instillGrey50"
-      readOnlyCursor="cursor-auto"
-      readOnlyInputBgColor="bg-white"
-      readOnlyInputBorderColor="border-instillGrey20"
-      readOnlyInputBorderStyle="border-solid"
-      readOnlyInputBorderWidth="border"
-      readOnlyInputTextColor="text-instillGrey95"
-      placeholderFontFamily="placeholder:font-sans"
-      placeholderFontSize="placeholder:text-base"
-      placeholderFontWeight="placeholder:font-normal"
-      placeholderLineHeight="placeholder:leading-[28px]"
-      placeholderTextColor="placeholder:text-instillGrey95"
-      labelFontSize="text-sm"
-      labelFontWeight="font-normal"
-      labelTextColor="text-instillGrey50"
-      labelLineHeight="leading-[18.2px]"
-      labelFontFamily="font-sans"
-      labelActivateStyle="top-1/2 -translate-y-[120%]"
-      labelDeActivateStyle="top-1/2 -translate-y-1/2"
-      errorInputBgColor="bg-white"
-      errorLabelFontFamily="font-sans"
-      errorLabelFontSize="text-sm"
-      errorLabelFontWeight="font-normal"
-      errorLabelLineHeight="leading-[18.2px]"
-      errorLabelTextColor="text-instillRed"
-      errorInputBorderColor="border-instillRed"
-      errorInputBorderWidth="border"
-      errorInputBorderStyle="border-solid"
-      errorInputTextColor="text-instillRed"
+      onChangeInput={props.onChangeInput}
+      additionalMessageOnLabel={props.additionalMessageOnLabel ?? null}
+      description={props.description ?? ""}
+      disabled={props.disabled ?? false}
+      required={props.required ?? false}
+      error={props.error ?? null}
+      placeholder={props.placeholder ?? ""}
+      readOnly={props.readOnly ?? false}
+      {...protectedBasicTextFieldConfig}
       {...basicInputDescriptionConfig}
     />
   );


### PR DESCRIPTION
Because

- instill-ai/community#348 
- We need a more flexible types inside of design-system

This commit

- add utility types for TextFields
