### PR TITLE
feat: accept additional JSX props at regular input field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -79,12 +79,6 @@ export type BasicInputProps = {
    */
   inputBgColor: string;
 
-  /**
-   * Whether the input is disabled
-   * @default false
-   */
-  disabled: boolean;
-
   /** TailwindCSS format - Background color when input is disabled
    * - e.g. bg-white
    * - https://tailwindcss.com/docs/background-color
@@ -120,17 +114,6 @@ export type BasicInputProps = {
    * - https://tailwindcss.com/docs/cursor
    */
   disabledCursor: string;
-
-  /**
-   * Text that appears in the form control when it has no value set
-   */
-  placeholder: string;
-
-  /**
-   * Whether The value is editable or not.
-   * @default false
-   */
-  readOnly: boolean;
 
   /** TailwindCSS format - Background color when input is read-only
    * - e.g. bg-white
@@ -205,12 +188,6 @@ export type BasicInputProps = {
   /** TailwindCSS format - The border radius of the input */
   inputBorderRadius: string;
 
-  /**
-   * Whether the field is necessary or not
-   * @default false
-   * */
-  required: boolean;
-
   /** TailwindCSS format
    * - Default is w-full, please make sure this component's parent has defined width
    * - if you are not sure about the defined number, please use abitrary number like w-[number-unit] w-[20px].
@@ -228,9 +205,6 @@ export type BasicInputProps = {
    * - if you are not sure about the defined number, please use abitrary number like w-[number-unit] w-[20px].
    */
   inputHeight: string;
-
-  /** Specific whether browser should help user auto complete the input or not */
-  autoComplete: string;
 
   /** They type of input label
    * - normal: Act as normal positioned title
@@ -370,8 +344,13 @@ export type PipelineState =
   | "STATE_ERROR";
 
 export type ConnectorState =
+  | "STATE_UNSPECIFIED"
   | "STATE_CONNECTED"
   | "STATE_DISCONNECTED"
   | "STATE_ERROR";
 
-export type ModelState = "STATE_ONLINE" | "STATE_OFFLINE" | "STATE_ERROR";
+export type ModelState =
+  | "STATE_ONLINE"
+  | "STATE_OFFLINE"
+  | "STATE_ERROR"
+  | "STATE_UNSPECIFIED";

--- a/src/ui/InputLabels/InputLabelBase/InputLabelBase.tsx
+++ b/src/ui/InputLabels/InputLabelBase/InputLabelBase.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import cn from "clsx";
 import { Nullable } from "../../../types/general";
 
-export interface InputLabelBaseProps {
+export type InputLabelBaseProps = {
   /** Input label's type
    * - normal: input label has normal position layout and doesn't have any animation
    * - inset: input label has absolution position layout, put into the input field and have float up animation with specific activate, deActivate style
@@ -28,12 +28,12 @@ export interface InputLabelBaseProps {
   htmlFor: string;
 
   /** Whether the input is required or not */
-  required: boolean;
+  required?: boolean | undefined;
 
   /** Whether the input is focused or not */
-  focus?: boolean;
+  focus?: boolean | undefined;
 
-  setFocus?: React.Dispatch<React.SetStateAction<boolean>>;
+  setFocus?: React.Dispatch<React.SetStateAction<boolean>> | undefined;
 
   /** Whether the input is answered or not */
   answered: boolean;
@@ -104,7 +104,7 @@ export interface InputLabelBaseProps {
    * - Don't need to specific translate-x-, it's fixed value
    */
   labelDeActivateStyle?: string;
-}
+};
 
 export type InputLabelBaseRef = HTMLLabelElement;
 

--- a/src/ui/SingleSelects/BasicSingleSelect/BasicSingleSelect.stories.tsx
+++ b/src/ui/SingleSelects/BasicSingleSelect/BasicSingleSelect.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { useState } from "react";
+import { ActionMeta } from "react-select";
+import { Nullable } from "../../../types/general";
 import { GrpcIcon, HttpIcon, MongoDbIcon, SnowflakeIcon } from "../../Icons";
 import { SingleSelectOption } from "../SingleSelectBase";
 import BasicSingleSelect from "./BasicSingleSelect";
@@ -51,8 +52,11 @@ const Template: ComponentStory<typeof BasicSingleSelect> = (args) => {
     },
   ];
 
-  const onChangeInputHandler = (inputValue: any) => {
-    console.log(inputValue);
+  const onChange = (
+    option: Nullable<SingleSelectOption>,
+    meta: ActionMeta<SingleSelectOption>
+  ) => {
+    console.log(option, meta);
   };
 
   return (
@@ -60,7 +64,7 @@ const Template: ComponentStory<typeof BasicSingleSelect> = (args) => {
       {...args}
       id="autocomplete-with-icon"
       instanceId="autocomplete-with-icon"
-      onChangeInput={onChangeInputHandler}
+      onChange={onChange}
       options={options}
       label="autocomplete-with-icon"
     />

--- a/src/ui/SingleSelects/BasicSingleSelect/BasicSingleSelect.tsx
+++ b/src/ui/SingleSelects/BasicSingleSelect/BasicSingleSelect.tsx
@@ -11,7 +11,7 @@ export type BasicSingleSelectRequiredKeys =
   | "label"
   | "value"
   | "options"
-  | "onChangeInput";
+  | "onChange";
 
 export type BasicSingleSelectOmitKeys =
   | "inputLabelType"
@@ -71,7 +71,7 @@ const BasicSingleSelect: React.FC<BasicSingleSelectProps> = (props) => {
     <SingleSelectBase
       id={props.id}
       instanceId={props.instanceId}
-      onChangeInput={props.onChangeInput}
+      onChange={props.onChange}
       value={props.value}
       options={props.options}
       label={props.label}

--- a/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.stories.tsx
+++ b/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.stories.tsx
@@ -73,10 +73,7 @@ const Template: ComponentStory<typeof SingleSelectBase> = (args) => {
     },
   ];
 
-  const onChangeInputHandler = (
-    id: string,
-    option: Nullable<SingleSelectOption>
-  ) => {
+  const onChange = (option: Nullable<SingleSelectOption>) => {
     setValue(option);
   };
 
@@ -85,7 +82,7 @@ const Template: ComponentStory<typeof SingleSelectBase> = (args) => {
   return (
     <SingleSelectBase
       {...args}
-      onChangeInput={onChangeInputHandler}
+      onChange={onChange}
       options={optionsWithoutIcon}
       value={value}
     />

--- a/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.tsx
+++ b/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.tsx
@@ -112,13 +112,17 @@ export type SingleSelectBaseProps = Omit<
   value: Nullable<SingleSelectOption>;
 
   /**
-   * The design system use actionMeta to provide additional info about the selection behavior. You could access these info inside the onChnageInput.
+   * The design system use actionMeta to provide additional info about the selection behavior.
+   * You could access these info inside the onChnage.
    */
-  onChangeInput: (
-    id: string,
+  onChange: (
     option: Nullable<SingleSelectOption>,
-    meta?: ActionMeta<SingleSelectOption>
+    meta: ActionMeta<SingleSelectOption>
   ) => void;
+
+  required?: boolean | undefined;
+  disabled?: boolean | undefined;
+  readOnly?: boolean | undefined;
 };
 
 const SelectBase: React.FC<SingleSelectBaseProps> = ({
@@ -132,7 +136,7 @@ const SelectBase: React.FC<SingleSelectBaseProps> = ({
   instanceId,
   error,
   description,
-  onChangeInput,
+  onChange,
   disabled,
   readOnly,
   isClearable,
@@ -379,11 +383,7 @@ const SelectBase: React.FC<SingleSelectBaseProps> = ({
             menuPlacement={menuPlacement ? menuPlacement : "auto"}
             options={options}
             onChange={(selectedOption, meta) => {
-              onChangeInput(
-                id,
-                selectedOption as SingleValue<SingleSelectOption>,
-                meta
-              );
+              onChange(selectedOption as SingleValue<SingleSelectOption>, meta);
 
               if (selectedOption) {
                 setAnswered(true);

--- a/src/ui/TextAreas/BasicTextArea/BasicTextArea.stories.tsx
+++ b/src/ui/TextAreas/BasicTextArea/BasicTextArea.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { useState } from "react";
+import { ChangeEvent, useState } from "react";
 import BasicTextArea from "./BasicTextArea";
 
 export default {
@@ -10,8 +10,8 @@ export default {
 const Template: ComponentStory<typeof BasicTextArea> = (args) => {
   const [value, setValue] = useState("");
 
-  const onChnageInput = (id: string, inputValue: string) => {
-    setValue(inputValue);
+  const onChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(event.target.value);
   };
 
   return (
@@ -22,7 +22,7 @@ const Template: ComponentStory<typeof BasicTextArea> = (args) => {
       placeholder="hello"
       description="this is a description for basic textarea <a href='#'>setup guide</a>"
       autoComplete="off"
-      onChangeInput={onChnageInput}
+      onChange={onChange}
       value={value}
     />
   );

--- a/src/ui/TextAreas/BasicTextArea/BasicTextArea.tsx
+++ b/src/ui/TextAreas/BasicTextArea/BasicTextArea.tsx
@@ -5,11 +5,7 @@ import {
 } from "../../InputDescriptions";
 import TextAreaBase, { TextAreaBaseProps } from "../TextAreaBase/TextAreaBase";
 
-export type BasicTextAreaRequiredKeys =
-  | "id"
-  | "value"
-  | "onChangeInput"
-  | "label";
+export type BasicTextAreaRequiredKeys = "id" | "value" | "onChange" | "label";
 
 export type BasicTextAreaOmitKeys =
   | "inputHeight"
@@ -145,7 +141,7 @@ const BasicTextArea: React.FC<BasicTextAreaProps> = (props) => {
     <TextAreaBase
       id={props.id}
       label={props.label}
-      onChangeInput={props.onChangeInput}
+      onChange={props.onChange}
       value={props.value}
       description={props.description ?? ""}
       additionalMessageOnLabel={props.additionalMessageOnLabel ?? null}

--- a/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
+++ b/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
@@ -329,6 +329,7 @@ const TextAreaBase: React.FC<TextAreaBaseProps> = ({
         />
         <div className="flex relative">
           <textarea
+            {...props}
             id={id}
             ref={inputRef}
             value={value ? value : ""}

--- a/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
+++ b/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
@@ -7,68 +7,65 @@ import { getElementPosition, getTailwindClassNumber } from "../../../utils";
 
 export type TextAreaBaseProps = Omit<
   BasicInputProps,
-  "labelActivateStyle" | "labelDeActivateStyle" | "onChangeInput"
-> & {
-  /** Textarea value */
-  value: Nullable<string>;
+  "labelActivateStyle" | "labelDeActivateStyle"
+> &
+  Omit<JSX.IntrinsicElements["textarea"], "onChange" | "value"> & {
+    /** Textarea value */
+    value: Nullable<string>;
 
-  /** Control how textarea can be resized
-   * This component currently not support resize
-   */
-  // resize: "both" | "none" | "x" | "y";
+    onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
 
-  /**
-   * Enable textarea words counter
-   * @default false
-   */
-  enableCounter: boolean;
+    /** Control how textarea can be resized
+     * This component currently not support resize
+     */
+    // resize: "both" | "none" | "x" | "y";
 
-  /**
-   * Textarea counter's words limit
-   */
-  counterWordLimit: number;
+    /**
+     * Enable textarea words counter
+     * @default false
+     */
+    enableCounter: boolean;
 
-  /** TailwindCSS format - Font size of textarea's counter
-   * - e.g. text-base
-   * - https://tailwindcss.com/docs/font-size
-   */
-  counterFontSize: string;
+    /**
+     * Textarea counter's words limit
+     */
+    counterWordLimit: number;
 
-  /** TailwindCSS format - Font family of textarea's counter
-   * - e.g. font-sans
-   * - https://tailwindcss.com/docs/font-family
-   */
-  counterFontFamily: string;
+    /** TailwindCSS format - Font size of textarea's counter
+     * - e.g. text-base
+     * - https://tailwindcss.com/docs/font-size
+     */
+    counterFontSize: string;
 
-  /** TailwindCSS format - Font weight of textarea's counter
-   * - e.g. font-normal
-   * - https://tailwindcss.com/docs/font-weight
-   */
-  counterFontWeight: string;
+    /** TailwindCSS format - Font family of textarea's counter
+     * - e.g. font-sans
+     * - https://tailwindcss.com/docs/font-family
+     */
+    counterFontFamily: string;
 
-  /** TailwindCSS format - Text color of textarea's counter
-   * - e.g. text-instillGrey50
-   * - https://tailwindcss.com/docs/text-color
-   */
-  counterTextColor: string;
+    /** TailwindCSS format - Font weight of textarea's counter
+     * - e.g. font-normal
+     * - https://tailwindcss.com/docs/font-weight
+     */
+    counterFontWeight: string;
 
-  /** TailwindCSS format - Line height of textarea's counter
-   * - e.g. leading-normal
-   * - https://tailwindcss.com/docs/line-height
-   */
-  counterLineHeight: string;
+    /** TailwindCSS format - Text color of textarea's counter
+     * - e.g. text-instillGrey50
+     * - https://tailwindcss.com/docs/text-color
+     */
+    counterTextColor: string;
 
-  onChangeInput: (
-    id: string,
-    inputValue: string,
-    event: React.ChangeEvent<HTMLTextAreaElement>
-  ) => void;
-};
+    /** TailwindCSS format - Line height of textarea's counter
+     * - e.g. leading-normal
+     * - https://tailwindcss.com/docs/line-height
+     */
+    counterLineHeight: string;
+  };
 
 const TextAreaBase: React.FC<TextAreaBaseProps> = ({
   id,
   value,
-  onChangeInput,
+  onChange,
   required,
   additionalMessageOnLabel,
   description,
@@ -139,6 +136,9 @@ const TextAreaBase: React.FC<TextAreaBaseProps> = ({
   errorLabelFontWeight,
   errorLabelLineHeight,
   errorLabelTextColor,
+  onFocus,
+  onBlur,
+  ...props
 }) => {
   const [focus, setFocus] = React.useState(false);
   const [answered, setAnswered] = React.useState(false);
@@ -360,16 +360,21 @@ const TextAreaBase: React.FC<TextAreaBaseProps> = ({
             readOnly={readOnly}
             autoComplete={autoComplete}
             onChange={(event) => {
-              const inputValue = event.target.value;
-              onChangeInput(id, event.target.value, event);
-              if (!inputValue) {
+              onChange(event);
+              if (!event.target.value) {
                 setAnswered(false);
                 return;
               }
               setAnswered(true);
             }}
-            onFocus={() => setFocus(true)}
-            onBlur={() => setFocus(false)}
+            onFocus={(event) => {
+              if (onFocus) onFocus(event);
+              setFocus(true);
+            }}
+            onBlur={(event) => {
+              if (onBlur) onBlur(event);
+              setFocus(false);
+            }}
           />
           {enableCounter ? (
             <div

--- a/src/ui/TextFields/BasicTextField/BasicTextField.stories.tsx
+++ b/src/ui/TextFields/BasicTextField/BasicTextField.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { useState } from "react";
+import { ChangeEvent, useState } from "react";
 import BasicTextField from "./BasicTextField";
 
 export default {
@@ -10,8 +10,8 @@ export default {
 const Template: ComponentStory<typeof BasicTextField> = (args) => {
   const [value, setValue] = useState("");
 
-  const onChnageInput = (id: string, inputValue: string) => {
-    setValue(inputValue);
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
   };
 
   return (
@@ -21,7 +21,7 @@ const Template: ComponentStory<typeof BasicTextField> = (args) => {
       label="text-field-playground"
       description="this is a description for text field <a href='#'>setup guide</a>"
       value={value}
-      onChangeInput={onChnageInput}
+      onChange={onChange}
     />
   );
 };

--- a/src/ui/TextFields/BasicTextField/BasicTextField.tsx
+++ b/src/ui/TextFields/BasicTextField/BasicTextField.tsx
@@ -5,11 +5,7 @@ import {
 } from "../../InputDescriptions";
 import TextFieldBase, { TextFieldBaseProps } from "../TextFieldBase";
 
-export type BasicTextFieldRequiredKeys =
-  | "id"
-  | "value"
-  | "onChangeInput"
-  | "label";
+export type BasicTextFieldRequiredKeys = "id" | "value" | "onChange" | "label";
 
 export type BasicTextFieldOmitKeys =
   | "inputHeight"
@@ -141,7 +137,7 @@ const BasicTextField: React.FC<BasicTextFieldProps> = (props) => {
     <TextFieldBase
       id={props.id}
       value={props.value}
-      onChangeInput={props.onChangeInput}
+      onChange={props.onChange}
       label={props.label}
       additionalMessageOnLabel={props.additionalMessageOnLabel ?? null}
       description={props.description ?? ""}

--- a/src/ui/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.stories.tsx
+++ b/src/ui/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { useState } from "react";
+import { ChangeEvent, useState } from "react";
 import ProtectedBasicTextField from "./ProtectedBasicTextField";
 
 export default {
@@ -10,8 +10,8 @@ export default {
 const Template: ComponentStory<typeof ProtectedBasicTextField> = (args) => {
   const [value, setValue] = useState("");
 
-  const onChnageInput = (id: string, inputValue: string) => {
-    setValue(inputValue);
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
   };
 
   return (
@@ -21,7 +21,7 @@ const Template: ComponentStory<typeof ProtectedBasicTextField> = (args) => {
       label="protected-text-field-playground"
       description="this is a description for protected text field <a href='#'>setup guide</a>"
       value={value}
-      onChangeInput={onChnageInput}
+      onChange={onChange}
     />
   );
 };

--- a/src/ui/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.tsx
+++ b/src/ui/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.tsx
@@ -8,7 +8,7 @@ import TextFieldBase, { TextFieldBaseProps } from "../TextFieldBase";
 export type ProtectedBasicTextFieldRequiredKeys =
   | "id"
   | "value"
-  | "onChangeInput"
+  | "onChange"
   | "label";
 
 export type ProtectedBasicTextFieldOmitKeys =
@@ -148,7 +148,7 @@ const ProtectedBasicTextField: React.FC<ProtectedBasicTextFieldProps> = (
       id={props.id}
       value={props.value}
       label={props.label}
-      onChangeInput={props.onChangeInput}
+      onChange={props.onChange}
       additionalMessageOnLabel={props.additionalMessageOnLabel ?? null}
       description={props.description ?? ""}
       disabled={props.disabled ?? false}

--- a/src/ui/TextFields/TextFieldBase/TextFieldBase.tsx
+++ b/src/ui/TextFields/TextFieldBase/TextFieldBase.tsx
@@ -14,26 +14,23 @@ import { getElementPosition, getTailwindClassNumber } from "../../../utils";
 //  - Use top-1/2 + (-translate-y-full) to move label up a little bit
 //  - If you want to change the InputLabel font size, you have to change the input's paddingTop and Input paddingTop
 
-export type TextFieldBaseProps = BasicInputProps & {
-  /** Text field's type
-   * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
-   */
-  type: string;
+export type TextFieldBaseProps = BasicInputProps &
+  Omit<JSX.IntrinsicElements["input"], "onChange" | "value"> & {
+    /** Text field's type
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
+     */
+    type: string;
 
-  /** Whether enable protected text toggle or not */
-  enableProtectedToggle: boolean;
+    /** Whether enable protected text toggle or not */
+    enableProtectedToggle: boolean;
 
-  value: Nullable<string>;
+    value: Nullable<string>;
 
-  onChangeInput: (
-    id: string,
-    inputValue: string,
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => void;
-};
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  };
 
 const TextFieldBase: React.FC<TextFieldBaseProps> = ({
-  onChangeInput,
+  onChange,
   id,
   additionalMessageOnLabel,
   required,
@@ -102,6 +99,9 @@ const TextFieldBase: React.FC<TextFieldBaseProps> = ({
   descriptionTextColor,
   descriptionLinkTextColor,
   descriptionLinkTextDecoration,
+  onFocus,
+  onBlur,
+  ...props
 }) => {
   const [focus, setFocus] = React.useState(false);
   const [answered, setAnswered] = React.useState(false);
@@ -267,6 +267,7 @@ const TextFieldBase: React.FC<TextFieldBaseProps> = ({
         />
         <div className="flex relative">
           <input
+            {...props}
             value={value ? value : ""}
             style={{
               height: containerHeight ? `${containerHeight}px` : "",
@@ -316,16 +317,21 @@ const TextFieldBase: React.FC<TextFieldBaseProps> = ({
             readOnly={readOnly}
             autoComplete={autoComplete}
             onChange={(event) => {
-              const inputValue = event.target.value;
-              onChangeInput(id, event.target.value, event);
-              if (!inputValue) {
+              onChange(event);
+              if (!event.target.value) {
                 setAnswered(false);
                 return;
               }
               setAnswered(true);
             }}
-            onFocus={() => setFocus(true)}
-            onBlur={() => setFocus(false)}
+            onFocus={(e) => {
+              if (onFocus) onFocus(e);
+              setFocus(true);
+            }}
+            onBlur={(e) => {
+              if (onBlur) onBlur(e);
+              setFocus(false);
+            }}
           />
           {enableProtectedToggle ? (
             <div className="absolute flex transform-gpu right-5 top-1/2 -translate-y-1/2">

--- a/src/ui/ToggleFields/BasicToggleField/BasicToggleField.stories.tsx
+++ b/src/ui/ToggleFields/BasicToggleField/BasicToggleField.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { useState } from "react";
+import { ChangeEvent, useState } from "react";
 import BasicToggleField from "./BasicToggleField";
 
 export default {
@@ -10,13 +10,14 @@ export default {
 const Template: ComponentStory<typeof BasicToggleField> = (args) => {
   const [checked, setChecked] = useState(false);
 
-  const onChangeInput = (_: string, value: boolean) => setChecked(value);
+  const onChange = (event: ChangeEvent<HTMLInputElement>) =>
+    setChecked(event.target.checked);
 
   return (
     <BasicToggleField
       {...args}
       id="basic-toggle-field"
-      onChangeInput={onChangeInput}
+      onChange={onChange}
       description="this is a description for basic toggle field <a href='#'>setup guide</a>"
       label="basic-toggle-field"
       value={checked}

--- a/src/ui/ToggleFields/BasicToggleField/BasicToggleField.tsx
+++ b/src/ui/ToggleFields/BasicToggleField/BasicToggleField.tsx
@@ -8,7 +8,7 @@ import ToggleFieldBase, { ToggleFieldBaseProps } from "../ToggleFieldBase";
 export type BasicToggleFieldRequiredKeys =
   | "id"
   | "value"
-  | "onChangeInput"
+  | "onChange"
   | "label";
 
 export type BasicToggleFieldOmitKeys =
@@ -124,7 +124,7 @@ const BasicToggleField: React.FC<BasicToggleFieldProps> = (props) => {
       id={props.id}
       value={props.value}
       label={props.label}
-      onChangeInput={props.onChangeInput}
+      onChange={props.onChange}
       description={props.description ?? ""}
       additionalMessageOnLabel={props.additionalMessageOnLabel ?? null}
       error={props.error ?? null}

--- a/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.stories.tsx
+++ b/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.stories.tsx
@@ -9,21 +9,19 @@ export default {
 } as ComponentMeta<typeof StatefulToggleField>;
 
 const Template: ComponentStory<typeof StatefulToggleField> = (args) => {
-  const [checked, setChecked] = useState(false);
   const [state, setState] = useState<State>("STATE_UNSPECIFIED");
 
   return (
     <StatefulToggleField
       {...args}
       id="basic-toggle-field"
-      onChangeInput={(_, value) => {
+      onChange={() => {
         setState("STATE_LOADING");
         setTimeout(() => {
           setState("STATE_ACTIVE");
-          setChecked(value);
-        }, 3000);
+        }, 1000);
       }}
-      value={checked}
+      value={state === "STATE_ACTIVE" ? true : false}
       description="this is a description for basic toggle field <a href='#'>setup guide</a>"
       label="basic-toggle-field"
       error={

--- a/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.tsx
+++ b/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.tsx
@@ -9,7 +9,7 @@ import ToggleFieldBase, { ToggleFieldBaseProps } from "../ToggleFieldBase";
 export type StatefulToggleFieldRequiredKeys =
   | "id"
   | "value"
-  | "onChangeInput"
+  | "onChange"
   | "label";
 
 export type StatefulToggleFieldOmitKeys =
@@ -116,7 +116,7 @@ const StatefulToggleField: React.FC<StatefulToggleFieldProps> = (props) => {
     <ToggleFieldBase
       id={props.id}
       value={props.value}
-      onChangeInput={props.onChangeInput}
+      onChange={props.onChange}
       label={props.label}
       additionalMessageOnLabel={
         props.state === "STATE_LOADING"

--- a/src/ui/ToggleFields/ToggleFieldBase/ToggleFieldBase.stories.tsx
+++ b/src/ui/ToggleFields/ToggleFieldBase/ToggleFieldBase.stories.tsx
@@ -14,8 +14,8 @@ const Template: ComponentStory<typeof ToggleFieldBase> = (args) => {
     <ToggleFieldBase
       {...args}
       value={checked}
-      onChangeInput={(_, value) => {
-        setChecked(value);
+      onChange={(event) => {
+        setChecked(event.target.checked);
       }}
     />
   );
@@ -27,7 +27,6 @@ export const Playground: ComponentStory<typeof ToggleFieldBase> = Template.bind(
 Playground.args = {
   required: true,
   focusHighlight: true,
-  onChangeInput: () => undefined,
   id: "toggle-field-base-playground",
   description: "this is a description for toggle field base",
 

--- a/src/ui/ToggleFields/ToggleFieldBase/ToggleFieldBase.tsx
+++ b/src/ui/ToggleFields/ToggleFieldBase/ToggleFieldBase.tsx
@@ -28,82 +28,79 @@ export type ToggleFieldBaseProps = Omit<
   | "errorInputBorderStyle"
   | "errorInputBorderWidth"
   | "errorInputTextColor"
-> & {
-  /** TailwindCSS format - Toggle center's dot color
-   * - Please use background-color, e.g. bg-blqck
-   */
+> &
+  Omit<JSX.IntrinsicElements["input"], "onChange" | "value"> & {
+    value: boolean;
 
-  dotColor: string;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 
-  /** TailwindCSS format - Toggle center's dot color when checked
-   * - e.g. bg-black
-   */
-  checkedDotColor: string;
+    /** TailwindCSS format - Toggle center's dot color
+     * - Please use background-color, e.g. bg-black
+     */
 
-  /** TailwindCSS format - Toggle border color when checked
-   * - e.g. border-black
-   */
-  checkedInputBorderColor: string;
+    dotColor: string;
 
-  /** TailwindCSS format - Toggle input border color when checked and disabled
-   * - e.g. border-black
-   */
-  disabledCheckedInputBorderColor: string;
+    /** TailwindCSS format - Toggle center's dot color when checked
+     * - e.g. bg-black
+     */
+    checkedDotColor: string;
 
-  /** TailwindCSS format - Toggle center's dot color when disabled
-   * - e.g. bg-black
-   */
-  disabledDotColor: string;
+    /** TailwindCSS format - Toggle border color when checked
+     * - e.g. border-black
+     */
+    checkedInputBorderColor: string;
 
-  /** TailwindCSS format - Toggle center's dot color when checked and disabled
-   * - e.g. bg-black
-   */
-  disabledCheckedDotColor: string;
+    /** TailwindCSS format - Toggle input border color when checked and disabled
+     * - e.g. border-black
+     */
+    disabledCheckedInputBorderColor: string;
 
-  /** TailwindCSS format - Toggle center's dot color when read-only
-   * - e.g. bg-black
-   */
-  readOnlyDotColor: string;
+    /** TailwindCSS format - Toggle center's dot color when disabled
+     * - e.g. bg-black
+     */
+    disabledDotColor: string;
 
-  /** TailwindCSS format - Toggle center's dot color when checked and read-only
-   * - e.g. bg-black
-   */
+    /** TailwindCSS format - Toggle center's dot color when checked and disabled
+     * - e.g. bg-black
+     */
+    disabledCheckedDotColor: string;
 
-  readOnlyCheckedDotColor: string;
+    /** TailwindCSS format - Toggle center's dot color when read-only
+     * - e.g. bg-black
+     */
+    readOnlyDotColor: string;
 
-  /** TailwindCSS format - Toggle input border color when checked and read-only
-   * - e.g. border-black
-   */
+    /** TailwindCSS format - Toggle center's dot color when checked and read-only
+     * - e.g. bg-black
+     */
 
-  readOnlyCheckedInputBorderColor: string;
+    readOnlyCheckedDotColor: string;
 
-  value: boolean;
+    /** TailwindCSS format - Toggle input border color when checked and read-only
+     * - e.g. border-black
+     */
 
-  /** TailwindCSS format - Toggle input border color when focus
-   * - e.g. border-black
-   */
+    readOnlyCheckedInputBorderColor: string;
 
-  inputFocusBorderColor: string;
+    /** TailwindCSS format - Toggle input border color when focus
+     * - e.g. border-black
+     */
 
-  /** TailwindCSS utility string - setup this custom style at instill plugin and use it
-   * - e.g. instill-input-shadow
-   * - When shadow string is not null, input field will show the shadow, if you want to display
-   *   shadow only when user focus on the input, please use inputFocusShadow
-   */
-  inputShadow: Nullable<string>;
+    inputFocusBorderColor: string;
 
-  /** TailwindCSS utility string - setup this custom style at instill plugin and use it
-   * - e.g. instill-input-focus-shadow
-   * - Show the shadow when user focus on input
-   */
-  inputFocusShadow: string;
+    /** TailwindCSS utility string - setup this custom style at instill plugin and use it
+     * - e.g. instill-input-shadow
+     * - When shadow string is not null, input field will show the shadow, if you want to display
+     *   shadow only when user focus on the input, please use inputFocusShadow
+     */
+    inputShadow: Nullable<string>;
 
-  onChangeInput: (
-    id: string,
-    inputValue: boolean,
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => void;
-};
+    /** TailwindCSS utility string - setup this custom style at instill plugin and use it
+     * - e.g. instill-input-focus-shadow
+     * - Show the shadow when user focus on input
+     */
+    inputFocusShadow: string;
+  };
 
 const ToggleFieldBase: React.FC<ToggleFieldBaseProps> = ({
   id,
@@ -115,7 +112,7 @@ const ToggleFieldBase: React.FC<ToggleFieldBaseProps> = ({
   readOnly,
   focusHighlight,
   required,
-  onChangeInput,
+  onChange,
   inputBorderRadius,
   inputBorderColor,
   inputBorderStyle,
@@ -164,6 +161,10 @@ const ToggleFieldBase: React.FC<ToggleFieldBaseProps> = ({
   errorLabelFontWeight,
   errorLabelLineHeight,
   errorLabelTextColor,
+  onFocus,
+  onBlur,
+  onClick,
+  ...props
 }) => {
   const [answered, setAnswered] = React.useState(false);
   const [focus, setFocus] = React.useState(false);
@@ -198,6 +199,7 @@ const ToggleFieldBase: React.FC<ToggleFieldBaseProps> = ({
           className={cn("flex relative w-[90px] h-10", inputBgColor)}
         >
           <input
+            {...props}
             id={id}
             aria-label={`${id}-label`}
             className={cn(
@@ -254,23 +256,26 @@ const ToggleFieldBase: React.FC<ToggleFieldBaseProps> = ({
                 return;
               }
 
-              onChangeInput(id, event.target.checked, event);
+              onChange(event);
 
               if (!answered) {
                 setAnswered(true);
               }
             }}
             onClick={(event) => {
+              if (onClick) onClick(event);
               if (readOnly) {
                 event.stopPropagation();
                 event.preventDefault();
                 return false;
               }
             }}
-            onFocus={() => {
+            onFocus={(event) => {
+              if (onFocus) onFocus(event);
               setFocus(true);
             }}
-            onBlur={() => {
+            onBlur={(event) => {
+              if (onBlur) onBlur(event);
               setFocus(false);
             }}
           />

--- a/src/ui/UploadFileFields/BasicUploadFileField/BasicUploadFileField.stories.tsx
+++ b/src/ui/UploadFileFields/BasicUploadFileField/BasicUploadFileField.stories.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent } from "react";
+import React, { ChangeEvent, FormEvent } from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import BasicUploadFileField from "./BasicUploadFileField";
 
@@ -18,7 +18,7 @@ Playground.args = {
   disabled: false,
   readOnly: false,
   required: true,
-  onChangeInput: () => undefined,
+  onChange: () => undefined,
   id: "upload-file-field-base-playground",
   label: "upload-file-field-base-playground",
   placeholder: "Upload a file",
@@ -30,16 +30,20 @@ Playground.args = {
 export const DemoFileReader: ComponentStory<
   typeof BasicUploadFileField
 > = () => {
-  const onChangeInput = (id: string, inputValue: File) => {
-    if (!inputValue) return;
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!event.target.value) return;
 
     const reader = new FileReader();
 
-    reader.readAsDataURL(inputValue);
+    const inputFileList = event.target.files;
 
-    reader.onloadend = () => {
-      console.log(reader.result);
-    };
+    if (inputFileList) {
+      reader.readAsDataURL(inputFileList[0]);
+
+      reader.onloadend = () => {
+        console.log(reader.result);
+      };
+    }
   };
 
   const onSubmitHandler = (event: FormEvent) => {
@@ -54,7 +58,7 @@ export const DemoFileReader: ComponentStory<
     >
       <BasicUploadFileField
         description="this is a description about upload file field  <a href='#'>setup guide</a>"
-        onChangeInput={onChangeInput}
+        onChange={onChange}
         required={true}
         id="upload-file-field-base-playground"
         label="upload-file-field-base-playground"

--- a/src/ui/UploadFileFields/BasicUploadFileField/BasicUploadFileField.tsx
+++ b/src/ui/UploadFileFields/BasicUploadFileField/BasicUploadFileField.tsx
@@ -9,7 +9,7 @@ import UploadFileFieldBase, {
 
 export type BasicUploadFileFieldRequiredKeys =
   | "id"
-  | "onChangeInput"
+  | "onChange"
   | "label"
   | "uploadButtonText";
 
@@ -139,7 +139,7 @@ const BasicUploadFileField: React.FC<BasicUploadFileFieldProps> = (props) => {
     <UploadFileFieldBase
       id={props.id}
       label={props.label}
-      onChangeInput={props.onChangeInput}
+      onChange={props.onChange}
       uploadButtonText={props.uploadButtonText}
       additionalMessageOnLabel={props.additionalMessageOnLabel ?? null}
       error={props.error ?? null}

--- a/src/ui/UploadFileFields/UploadFileFieldBase/UploadFileFieldBase.stories.tsx
+++ b/src/ui/UploadFileFields/UploadFileFieldBase/UploadFileFieldBase.stories.tsx
@@ -18,7 +18,7 @@ Playground.args = {
   required: true,
   focusHighlight: true,
   id: "upload-file-field-base-playground",
-  onChangeInput: () => undefined,
+  onChange: () => undefined,
   inputLabelType: "inset",
   placeholder: "playground",
 

--- a/src/ui/UploadFileFields/UploadFileFieldBase/UploadFileFieldBase.tsx
+++ b/src/ui/UploadFileFields/UploadFileFieldBase/UploadFileFieldBase.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, useState } from "react";
+import React from "react";
 import { BasicInputProps, Nullable } from "../../../types/general";
 import cn from "clsx";
 import { DocIcon } from "../../Icons";
@@ -18,58 +18,55 @@ export type UploadFileFieldBaseProps = Omit<
   | "placeholderFontWeight"
   | "placeholderLineHeight"
   | "placeholderTextColor"
-> & {
-  /** Text display on upload button */
-  uploadButtonText: string;
+> &
+  Omit<JSX.IntrinsicElements["input"], "onChange" | "value"> & {
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 
-  /** TailwindCSS format
-   * - e.g. bg-instillGrey50
-   */
-  uploadButtonBgColor: string;
+    /** Text display on upload button */
+    uploadButtonText: string;
 
-  /** TailwindCSS format
-   * - use group-hover utility
-   * - e.g. group-hover:bg-instillGrey50
-   */
-  uploadButtonHoverBgColor: string;
+    /** TailwindCSS format
+     * - e.g. bg-instillGrey50
+     */
+    uploadButtonBgColor: string;
 
-  /** TailwindCSS format
-   * - e.g. text-instillGrey05
-   */
-  uploadButtonTextColor: string;
+    /** TailwindCSS format
+     * - use group-hover utility
+     * - e.g. group-hover:bg-instillGrey50
+     */
+    uploadButtonHoverBgColor: string;
 
-  /** TailwindCSS format
-   * - use group-hover utility
-   * - e.g. group-hover:text-instillGrey50
-   */
-  uploadButtonHoverTextColor: string;
+    /** TailwindCSS format
+     * - e.g. text-instillGrey05
+     */
+    uploadButtonTextColor: string;
 
-  /** TailwindCSS format - Input's top right border radius
-   * - e.g. rounded-tr-[1px]
-   */
-  inputBorderRadiusTopRight: string;
+    /** TailwindCSS format
+     * - use group-hover utility
+     * - e.g. group-hover:text-instillGrey50
+     */
+    uploadButtonHoverTextColor: string;
 
-  /** TailwindCSS format - Input's bottom right border radius
-   * - e.g. rounded-br-[1px]
-   */
-  inputBorderRadiusBottomRight: string;
+    /** TailwindCSS format - Input's top right border radius
+     * - e.g. rounded-tr-[1px]
+     */
+    inputBorderRadiusTopRight: string;
 
-  /** TailwindCSS format - Input's top left border radius
-   * - e.g. rounded-tl-[1px]
-   */
-  inputBorderRadiusTopLeft: string;
+    /** TailwindCSS format - Input's bottom right border radius
+     * - e.g. rounded-br-[1px]
+     */
+    inputBorderRadiusBottomRight: string;
 
-  /** TailwindCSS format - Input's bottom left border radius
-   * - e.g. rounded-bl-[1px]
-   */
-  inputBorderRadiusBottomLeft: string;
+    /** TailwindCSS format - Input's top left border radius
+     * - e.g. rounded-tl-[1px]
+     */
+    inputBorderRadiusTopLeft: string;
 
-  onChangeInput: (
-    id: string,
-    inputValue: any,
-    event: Nullable<React.ChangeEvent<HTMLInputElement>>
-  ) => void;
-};
+    /** TailwindCSS format - Input's bottom left border radius
+     * - e.g. rounded-bl-[1px]
+     */
+    inputBorderRadiusBottomLeft: string;
+  };
 
 const UploadFileFieldBase: React.FC<UploadFileFieldBaseProps> = ({
   id,
@@ -95,7 +92,7 @@ const UploadFileFieldBase: React.FC<UploadFileFieldBaseProps> = ({
   inputFontWeight,
   inputLineHeight,
   inputTextColor,
-  onChangeInput,
+  onChange,
   disabled,
   readOnly,
   inputBorderColor,
@@ -137,6 +134,8 @@ const UploadFileFieldBase: React.FC<UploadFileFieldBaseProps> = ({
   readOnlyInputBorderStyle,
   readOnlyInputBorderWidth,
   readOnlyInputTextColor,
+  onClick,
+  ...props
 }) => {
   const [answered, setAnswered] = React.useState(false);
   const [file, setFile] = React.useState<Nullable<string>>(null);
@@ -144,6 +143,7 @@ const UploadFileFieldBase: React.FC<UploadFileFieldBaseProps> = ({
     React.useState<Nullable<number>>(null);
   const [containerHeight, setContainerHeight] =
     React.useState<Nullable<number>>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   /**
    * We use these ref to calculate the width and height of the container
@@ -229,14 +229,14 @@ const UploadFileFieldBase: React.FC<UploadFileFieldBaseProps> = ({
     }
   }, [error, inputLabelRef, inputValueRef, inputLabelType]);
 
-  const handleInputOnClick = (event: MouseEvent<HTMLInputElement>) => {
+  const handleInputOnClick = (event: React.MouseEvent<HTMLInputElement>) => {
     if (readOnly) {
       event.preventDefault();
       event.stopPropagation();
     }
   };
 
-  const handleButtonOnClick = (event: MouseEvent<HTMLDivElement>) => {
+  const handleButtonOnClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (readOnly || disabled) return;
 
     if (answered) {
@@ -244,11 +244,13 @@ const UploadFileFieldBase: React.FC<UploadFileFieldBaseProps> = ({
       setFile("");
       setFileInputKey(Math.random().toString(36));
       setAnswered(false);
-      onChangeInput(id, null, null);
+      if (inputRef.current) {
+        inputRef.current.value = "";
+      }
     }
   };
 
-  const [fileInputKey, setFileInputKey] = useState<string>("");
+  const [fileInputKey, setFileInputKey] = React.useState<string>("");
 
   React.useEffect(() => {
     setFileInputKey(Math.random().toString(36));
@@ -387,6 +389,8 @@ const UploadFileFieldBase: React.FC<UploadFileFieldBaseProps> = ({
             ) : null}
           </div>
           <input
+            {...props}
+            ref={inputRef}
             key={fileInputKey}
             className={cn(
               "opacity-0 overflow-hidden absolute",
@@ -399,8 +403,8 @@ const UploadFileFieldBase: React.FC<UploadFileFieldBaseProps> = ({
             disabled={disabled}
             readOnly={readOnly}
             onChange={(event) => {
+              onChange(event);
               const inputValue = event.target.value;
-              const inputFileList = event.target.files || null;
 
               if (!inputValue) {
                 setAnswered(false);
@@ -409,12 +413,11 @@ const UploadFileFieldBase: React.FC<UploadFileFieldBaseProps> = ({
 
               setAnswered(true);
               setFile(inputValue);
-
-              if (inputFileList) {
-                onChangeInput(id, inputFileList[0], event);
-              }
             }}
-            onClick={(event) => handleInputOnClick(event)}
+            onClick={(event) => {
+              if (onClick) onClick(event);
+              handleInputOnClick(event);
+            }}
           />
           <div
             ref={uploadButtonRef}


### PR DESCRIPTION
# Because

- Before this change, we only accept pre-defined props. For example, the component below can't have onBlur (JSX props) to it.

```js
<BasicSingleSelect
  id="autocomplete-with-icon"
  instanceId="autocomplete-with-icon"
  onChange={onChange}
  options={options}
  label="autocomplete-with-icon"
/>
```

- After this change, we could safely pass JSX prop into our component

```js
<BasicSingleSelect
  id="autocomplete-with-icon"
  instanceId="autocomplete-with-icon"
  onChange={onChange}
  options={options}
  label="autocomplete-with-icon"
  onBlur={onBlurHandler}
/>
```

# This commit

- Replace our defined props with JSX props at InputField
- Rename onChangeInput to onChange
