### PR TITLE
fix: fix VdpLogoProps is not correctly exported

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.107",
+  "version": "0.0.108",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/ui/Logo/index.ts
+++ b/src/ui/Logo/index.ts
@@ -4,4 +4,4 @@ import VdpLogo from "./VdpLogo";
 import type { VdpLogoProps } from "./VdpLogo";
 
 export { Logo, VdpLogo };
-export type { LogoProps };
+export type { LogoProps, VdpLogoProps };


### PR DESCRIPTION
Because

- VdpLogoProps is not correctly exported

This commit

- Export VdpLogoProps
