### PR TITLE
chore: rename button props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.115",
+  "version": "0.0.116",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/ui/Buttons/ButtonBase/ButtonBase.tsx
+++ b/src/ui/Buttons/ButtonBase/ButtonBase.tsx
@@ -117,11 +117,11 @@ export type ButtonBaseProps = {
   endIcon: Nullable<React.ReactElement>;
 
   /**
-   * TailwindCSS format - Gap between icon and text in the button
+   * TailwindCSS format - Space between icon and text in the button
    * - It will only apply when startIcon or endIcon is present
-   * - e.g. gap-x-2
+   * - e.g. space-x-2
    */
-  itemGapX: Nullable<string>;
+  itemSpaceX: Nullable<string>;
 
   children?: React.ReactNode;
 };
@@ -148,7 +148,7 @@ const ButtonBase = ({
   disabledBorderColor,
   startIcon,
   endIcon,
-  itemGapX,
+  itemSpaceX,
 }: ButtonBaseProps) => {
   return (
     <button
@@ -158,7 +158,7 @@ const ButtonBase = ({
       data-flag={dataFlag}
       className={cn(
         "group rounded-[1px] flex flex-row",
-        startIcon ? itemGapX : endIcon ? itemGapX : "",
+        startIcon ? itemSpaceX : endIcon ? itemSpaceX : "",
         disabled
           ? cn(
               disabledBgColor,

--- a/src/ui/Buttons/CollapseSidebarButton/CollapseSidebarButton.tsx
+++ b/src/ui/Buttons/CollapseSidebarButton/CollapseSidebarButton.tsx
@@ -20,7 +20,7 @@ export type CollapseSidebarButtonOmitKeys =
   | "borderRadius"
   | "startIcon"
   | "endIcon"
-  | "itemGapX"
+  | "itemSpaceX"
   | "type";
 
 export type CollapseSidebarButtonConfig = Pick<
@@ -37,7 +37,7 @@ export const collapseSidebarButtonConfig: CollapseSidebarButtonConfig = {
   hoveredBorderColor: null,
   startIcon: null,
   endIcon: null,
-  itemGapX: null,
+  itemSpaceX: null,
   bgColor: "bg-instillGrey90",
   borderRadius: null,
   hoveredBgColor: "hover:bg-instillGrey80",

--- a/src/ui/Buttons/OutlineButton/OutlineButton.stories.tsx
+++ b/src/ui/Buttons/OutlineButton/OutlineButton.stories.tsx
@@ -24,7 +24,7 @@ export const DiscordButton: ComponentStory<typeof OutlineButton> =
 
 DiscordButton.args = {
   color: "primary",
-  itemGapX: "gap-x-3",
+  itemSpaceX: "space-x-3",
   startIcon: (
     <DiscordIcon
       width="w-5"
@@ -41,7 +41,7 @@ export const MediumButton: ComponentStory<typeof OutlineButton> = Template.bind(
 
 MediumButton.args = {
   color: "primary",
-  itemGapX: "gap-x-3",
+  itemSpaceX: "space-x-3",
   endIcon: (
     <MediumIcon
       width="w-5"

--- a/src/ui/Buttons/OutlineButton/OutlineButton.tsx
+++ b/src/ui/Buttons/OutlineButton/OutlineButton.tsx
@@ -107,7 +107,7 @@ const OutlineButton: React.FC<OutlineButtonProps> = (props) => {
       padding={props.padding ?? "px-5 py-2.5"}
       startIcon={props.startIcon ?? null}
       endIcon={props.endIcon ?? null}
-      itemGapX={props.itemGapX ?? null}
+      itemSpaceX={props.itemSpaceX ?? null}
       {...buttonStyle}
     >
       {props.children}

--- a/src/ui/Buttons/SolidButton/SolidButton.tsx
+++ b/src/ui/Buttons/SolidButton/SolidButton.tsx
@@ -91,7 +91,7 @@ const SolidButton: React.FC<SolidButtonProps> = (props) => {
       padding={props.padding ?? "px-5 py-2.5"}
       startIcon={props.startIcon ?? null}
       endIcon={props.endIcon ?? null}
-      itemGapX={props.itemGapX ?? null}
+      itemSpaceX={props.itemSpaceX ?? null}
       {...buttonStyle}
     >
       {props.children}

--- a/src/ui/Buttons/TextButton/TextButton.stories.tsx
+++ b/src/ui/Buttons/TextButton/TextButton.stories.tsx
@@ -20,7 +20,7 @@ export const withIcon: ComponentStory<typeof TextButton> = Template.bind({});
 
 withIcon.args = {
   color: "primary",
-  itemGapX: "gap-x-5",
+  itemSpaceX: "space-x-5",
   endIcon: (
     <ArrowRightIcon
       width="w-4"

--- a/src/ui/Buttons/TextButton/TextButton.tsx
+++ b/src/ui/Buttons/TextButton/TextButton.tsx
@@ -87,7 +87,7 @@ const TextButton: React.FC<TextButtonProps> = (props) => {
       padding={props.padding ?? "px-5 py-2.5"}
       startIcon={props.startIcon ?? null}
       endIcon={props.endIcon ?? null}
-      itemGapX={props.itemGapX ?? null}
+      itemSpaceX={props.itemSpaceX ?? null}
       {...buttonStyle}
     >
       {props.children}


### PR DESCRIPTION
Because

- We use itemGapX in button that is misleading

This commit

- rename button props from itemGapX to itemSpaceX
