### PR TITLE
feat: add textSize prop and roll back to itemGapX on Buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.116",
+  "version": "0.0.117",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/ui/Buttons/ButtonBase/ButtonBase.tsx
+++ b/src/ui/Buttons/ButtonBase/ButtonBase.tsx
@@ -39,6 +39,11 @@ export type ButtonBaseProps = {
    */
   textColor: Nullable<string>;
 
+  /** TailwindCSS format - The font size of the button
+   * - e.g. text-base
+   */
+  textSize: Nullable<string>;
+
   /** TailwindCSS format - The text color of the button when hovered
    * - Please use Tailwind hover state
    * - e.g. hover:text-blue-100
@@ -121,7 +126,7 @@ export type ButtonBaseProps = {
    * - It will only apply when startIcon or endIcon is present
    * - e.g. space-x-2
    */
-  itemSpaceX: Nullable<string>;
+  itemGapX: Nullable<string>;
 
   children?: React.ReactNode;
 };
@@ -133,6 +138,7 @@ const ButtonBase = ({
   disabledBgColor,
   disabledTextColor,
   textColor,
+  textSize,
   hoveredTextColor,
   onClickHandler,
   position,
@@ -148,7 +154,7 @@ const ButtonBase = ({
   disabledBorderColor,
   startIcon,
   endIcon,
-  itemSpaceX,
+  itemGapX,
 }: ButtonBaseProps) => {
   return (
     <button
@@ -158,7 +164,7 @@ const ButtonBase = ({
       data-flag={dataFlag}
       className={cn(
         "group rounded-[1px] flex flex-row",
-        startIcon ? itemSpaceX : endIcon ? itemSpaceX : "",
+        startIcon ? itemGapX : endIcon ? itemGapX : "",
         disabled
           ? cn(
               disabledBgColor,
@@ -177,6 +183,7 @@ const ButtonBase = ({
         position,
         padding,
         width,
+        textSize,
         borderSize,
         borderRadius
       )}

--- a/src/ui/Buttons/CollapseSidebarButton/CollapseSidebarButton.tsx
+++ b/src/ui/Buttons/CollapseSidebarButton/CollapseSidebarButton.tsx
@@ -20,8 +20,9 @@ export type CollapseSidebarButtonOmitKeys =
   | "borderRadius"
   | "startIcon"
   | "endIcon"
-  | "itemSpaceX"
-  | "type";
+  | "itemGapX"
+  | "type"
+  | "textSize";
 
 export type CollapseSidebarButtonConfig = Pick<
   ButtonBaseProps,
@@ -37,7 +38,7 @@ export const collapseSidebarButtonConfig: CollapseSidebarButtonConfig = {
   hoveredBorderColor: null,
   startIcon: null,
   endIcon: null,
-  itemSpaceX: null,
+  itemGapX: null,
   bgColor: "bg-instillGrey90",
   borderRadius: null,
   hoveredBgColor: "hover:bg-instillGrey80",
@@ -46,6 +47,7 @@ export const collapseSidebarButtonConfig: CollapseSidebarButtonConfig = {
   disabledBgColor: "bg-instillGrey90",
   disabledTextColor: null,
   padding: "p-[3px]",
+  textSize: null,
 };
 
 export type FullCollapseSidebarButtonProps = Omit<

--- a/src/ui/Buttons/OutlineButton/OutlineButton.stories.tsx
+++ b/src/ui/Buttons/OutlineButton/OutlineButton.stories.tsx
@@ -24,7 +24,7 @@ export const DiscordButton: ComponentStory<typeof OutlineButton> =
 
 DiscordButton.args = {
   color: "primary",
-  itemSpaceX: "space-x-3",
+  itemGapX: "gap-x-3",
   startIcon: (
     <DiscordIcon
       width="w-5"
@@ -41,7 +41,7 @@ export const MediumButton: ComponentStory<typeof OutlineButton> = Template.bind(
 
 MediumButton.args = {
   color: "primary",
-  itemSpaceX: "space-x-3",
+  itemGapX: "gap-x-3",
   endIcon: (
     <MediumIcon
       width="w-5"

--- a/src/ui/Buttons/OutlineButton/OutlineButton.tsx
+++ b/src/ui/Buttons/OutlineButton/OutlineButton.tsx
@@ -107,7 +107,8 @@ const OutlineButton: React.FC<OutlineButtonProps> = (props) => {
       padding={props.padding ?? "px-5 py-2.5"}
       startIcon={props.startIcon ?? null}
       endIcon={props.endIcon ?? null}
-      itemSpaceX={props.itemSpaceX ?? null}
+      itemGapX={props.itemGapX ?? null}
+      textSize={props.textSize ?? "text-base"}
       {...buttonStyle}
     >
       {props.children}

--- a/src/ui/Buttons/SolidButton/SolidButton.tsx
+++ b/src/ui/Buttons/SolidButton/SolidButton.tsx
@@ -91,7 +91,8 @@ const SolidButton: React.FC<SolidButtonProps> = (props) => {
       padding={props.padding ?? "px-5 py-2.5"}
       startIcon={props.startIcon ?? null}
       endIcon={props.endIcon ?? null}
-      itemSpaceX={props.itemSpaceX ?? null}
+      itemGapX={props.itemGapX ?? null}
+      textSize={props.textSize ?? "text-base"}
       {...buttonStyle}
     >
       {props.children}

--- a/src/ui/Buttons/TextButton/TextButton.stories.tsx
+++ b/src/ui/Buttons/TextButton/TextButton.stories.tsx
@@ -20,7 +20,8 @@ export const withIcon: ComponentStory<typeof TextButton> = Template.bind({});
 
 withIcon.args = {
   color: "primary",
-  itemSpaceX: "space-x-5",
+  itemGapX: "gap-x-5",
+  textSize: "text-2xl",
   endIcon: (
     <ArrowRightIcon
       width="w-4"

--- a/src/ui/Buttons/TextButton/TextButton.tsx
+++ b/src/ui/Buttons/TextButton/TextButton.tsx
@@ -84,10 +84,11 @@ const TextButton: React.FC<TextButtonProps> = (props) => {
       position={props.position ?? null}
       dataFlag={props.dataFlag ?? null}
       width={props.width ?? null}
-      padding={props.padding ?? "px-5 py-2.5"}
       startIcon={props.startIcon ?? null}
       endIcon={props.endIcon ?? null}
-      itemSpaceX={props.itemSpaceX ?? null}
+      itemGapX={props.itemGapX ?? null}
+      padding={props.padding ?? "px-5 py-2.5"}
+      textSize={props.textSize ?? "text-base"}
       {...buttonStyle}
     >
       {props.children}


### PR DESCRIPTION
Because

- Tailwind support gap on flexbox now https://tailwindcss.com/docs/gap
- We need a way to control button text size

This commit

- Add textSize prop on Button
- Roll back to itemGapX on Buttons
