### PR TITLE
feat: extend background opacity related props in ButtonBase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.120",
+  "version": "0.0.121",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/ui/Buttons/ButtonBase/ButtonBase.tsx
+++ b/src/ui/Buttons/ButtonBase/ButtonBase.tsx
@@ -23,16 +23,32 @@ export type ButtonBaseProps = {
    */
   bgColor: Nullable<string>;
 
+  /** TailwindCSS format - The opacity of background color of the button
+   * - e.g. bg-opacity-50
+   */
+
+  bgOpacity: Nullable<string>;
+
   /** TailwindCSS format - The background color of the button when hovered
    * - Please use Tailwind hover state
    * - e.g. hover:bg-blue-100
    */
   hoveredBgColor: Nullable<string>;
 
+  /** TailwindCSS format - The opacity of background color of the button when hovered
+   * - e.g. hover:bg-opacity-50
+   */
+  hoveredBgOpacity: Nullable<string>;
+
   /** TailwindCSS format - The background color of the button when disabled
    * - e.g. bg-slate-100
    */
   disabledBgColor: Nullable<string>;
+
+  /** TailwindCSS format - The opacity of background color of the button when disabled
+   * - e.g. bg-opacity-50
+   */
+  disabledBgOpacity: Nullable<string>;
 
   /** TailwindCSS format - The text color of the button
    * - e.g. text-black
@@ -133,13 +149,18 @@ export type ButtonBaseProps = {
 
 const ButtonBase = ({
   bgColor,
-  hoveredBgColor,
+  bgOpacity,
   disabled,
   disabledBgColor,
+  disabledBgOpacity,
+  disabledBorderColor,
   disabledTextColor,
   textColor,
   textSize,
   hoveredTextColor,
+  hoveredBorderColor,
+  hoveredBgColor,
+  hoveredBgOpacity,
   onClickHandler,
   position,
   type,
@@ -150,8 +171,6 @@ const ButtonBase = ({
   borderSize,
   borderColor,
   borderRadius,
-  hoveredBorderColor,
-  disabledBorderColor,
   startIcon,
   endIcon,
   itemGapX,
@@ -168,13 +187,16 @@ const ButtonBase = ({
         disabled
           ? cn(
               disabledBgColor,
+              disabledBgOpacity,
               disabledTextColor,
               disabledBorderColor,
               "cursor-not-allowed"
             )
           : cn(
               bgColor,
+              bgOpacity,
               hoveredBgColor,
+              hoveredBgOpacity,
               textColor,
               hoveredTextColor,
               borderColor,

--- a/src/ui/Buttons/CollapseSidebarButton/CollapseSidebarButton.tsx
+++ b/src/ui/Buttons/CollapseSidebarButton/CollapseSidebarButton.tsx
@@ -6,15 +6,18 @@ export type CollapseSidebarButtonRequiredKeys = "onClickHandler" | "isCollapse";
 
 export type CollapseSidebarButtonOmitKeys =
   | "bgColor"
+  | "bgOpacity"
   | "textColor"
   | "disabledBgColor"
+  | "disabledBgOpacity"
   | "disabledTextColor"
+  | "disabledBorderColor"
   | "padding"
   | "width"
   | "borderSize"
   | "borderColor"
-  | "disabledBorderColor"
   | "hoveredBgColor"
+  | "hoveredBgOpacity"
   | "hoveredTextColor"
   | "hoveredBorderColor"
   | "borderRadius"
@@ -48,6 +51,9 @@ export const collapseSidebarButtonConfig: CollapseSidebarButtonConfig = {
   disabledTextColor: null,
   padding: "p-[3px]",
   textSize: null,
+  disabledBgOpacity: null,
+  hoveredBgOpacity: null,
+  bgOpacity: null,
 };
 
 export type FullCollapseSidebarButtonProps = Omit<

--- a/src/ui/Buttons/OutlineButton/OutlineButton.tsx
+++ b/src/ui/Buttons/OutlineButton/OutlineButton.tsx
@@ -9,8 +9,11 @@ export type OutlineButtonOmitKeys =
   | "hoveredBorderColor"
   | "disabledBorderColor"
   | "bgColor"
+  | "bgOpacity"
   | "disabledBgColor"
+  | "disabledBgOpacity"
   | "hoveredBgColor"
+  | "hoveredBgOpacity"
   | "textColor"
   | "hoveredTextColor"
   | "disabledTextColor"
@@ -54,6 +57,9 @@ const OutlineButton: React.FC<OutlineButtonProps> = (props) => {
         textColor: "text-instillBlue50",
         hoveredTextColor: "hover:text-instillBlue10",
         disabledTextColor: "text-instillGrey30",
+        disabledBgOpacity: null,
+        hoveredBgOpacity: null,
+        bgOpacity: null,
       };
       break;
     }
@@ -70,6 +76,9 @@ const OutlineButton: React.FC<OutlineButtonProps> = (props) => {
         textColor: "text-instillGrey50",
         hoveredTextColor: "hover:text-instillGrey05",
         disabledTextColor: "text-instillGrey30",
+        disabledBgOpacity: null,
+        hoveredBgOpacity: null,
+        bgOpacity: null,
       };
       break;
     }
@@ -86,6 +95,9 @@ const OutlineButton: React.FC<OutlineButtonProps> = (props) => {
         textColor: "text-instillRed",
         hoveredTextColor: "hover:text-instillRed10",
         disabledTextColor: "text-instillGrey30",
+        disabledBgOpacity: null,
+        hoveredBgOpacity: null,
+        bgOpacity: null,
       };
       break;
     }

--- a/src/ui/Buttons/SolidButton/SolidButton.tsx
+++ b/src/ui/Buttons/SolidButton/SolidButton.tsx
@@ -9,8 +9,11 @@ export type SolidButtonOmitKeys =
   | "hoveredBorderColor"
   | "disabledBorderColor"
   | "bgColor"
+  | "bgOpacity"
   | "disabledBgColor"
+  | "disabledBgOpacity"
   | "hoveredBgColor"
+  | "hoveredBgOpacity"
   | "textColor"
   | "hoveredTextColor"
   | "disabledTextColor"
@@ -22,7 +25,7 @@ export type FullSolidButtonProps = Omit<
   ButtonBaseProps,
   SolidButtonOmitKeys
 > & {
-  color: "primary";
+  color: "primary" | "primaryLight";
 };
 
 export type SolidButtonRequiredProps = Pick<
@@ -54,6 +57,28 @@ const SolidButton: React.FC<SolidButtonProps> = (props) => {
         hoveredTextColor: "hover:text-instillBlue10",
         disabledBgColor: "bg-instillGrey15",
         disabledTextColor: "text-instillGrey50",
+        disabledBgOpacity: null,
+        hoveredBgOpacity: null,
+        bgOpacity: null,
+      };
+      break;
+    }
+    case "primaryLight": {
+      buttonStyle = {
+        borderSize: null,
+        borderColor: null,
+        hoveredBorderColor: null,
+        disabledBorderColor: null,
+        borderRadius: "rounded-[1px]",
+        bgColor: "bg-instillNeonBlue",
+        hoveredBgColor: "hover:bg-instillNeonBlue",
+        textColor: "text-instillNeonBlue",
+        hoveredTextColor: "hover:text-instillNeonBlue",
+        disabledBgColor: "bg-instillGrey15",
+        disabledTextColor: "text-instillGrey50",
+        disabledBgOpacity: null,
+        bgOpacity: "bg-opacity-10",
+        hoveredBgOpacity: "hover:bg-opacity-20",
       };
       break;
     }

--- a/src/ui/Buttons/TextButton/TextButton.tsx
+++ b/src/ui/Buttons/TextButton/TextButton.tsx
@@ -9,8 +9,11 @@ export type TextButtonOmitKeys =
   | "hoveredBorderColor"
   | "disabledBorderColor"
   | "bgColor"
+  | "bgOpacity"
   | "disabledBgColor"
+  | "disabledBgOpacity"
   | "hoveredBgColor"
+  | "hoveredBgOpacity"
   | "textColor"
   | "hoveredTextColor"
   | "disabledTextColor"
@@ -50,6 +53,9 @@ const TextButton: React.FC<TextButtonProps> = (props) => {
         hoveredTextColor: "hover:text-instillBlue80",
         disabledBgColor: null,
         disabledTextColor: "text-instillGrey50",
+        disabledBgOpacity: null,
+        hoveredBgOpacity: null,
+        bgOpacity: null,
       };
       break;
     }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -44,7 +44,8 @@ module.exports = {
         instillGreen: "#28F67E",
         instillGreen10: "#ECFFF0",
         instillGreen50: "#02D12F",
-        instillNeonBlue: "#0000FF",
+        instillNeonBlue50: "#0000FF",
+        instillNeonBlue: "#23C4E7",
       },
       fontFamily: {
         mono: ["IBM Plex Mono", ...defaultTheme.fontFamily.mono],


### PR DESCRIPTION
Because we need to have different color variants that involve background color opacity. This commit extends the props of ButtonBase and add primaryLight variant into SolidButton
