### PR TITLE
feat: expose blur/focus event of select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.125",
+  "version": "0.0.126",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/ui/SingleSelects/BasicSingleSelect/BasicSingleSelect.tsx
+++ b/src/ui/SingleSelects/BasicSingleSelect/BasicSingleSelect.tsx
@@ -76,6 +76,8 @@ const BasicSingleSelect: React.FC<BasicSingleSelectProps> = (props) => {
       value={props.value}
       options={props.options}
       label={props.label}
+      onFocus={props.onFocus ?? null}
+      onBlur={props.onBlur ?? null}
       additionalMessageOnLabel={props.additionalMessageOnLabel ?? null}
       menuPlacement={props.menuPlacement ?? "auto"}
       description={props.description ?? ""}

--- a/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.stories.tsx
+++ b/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.stories.tsx
@@ -61,4 +61,10 @@ Playground.args = {
   id: "single-select-with-icon",
   ...basicSingleSelectConfig,
   ...basicInputDescriptionConfig,
+  onFocus: () => {
+    console.log("Focused");
+  },
+  onBlur: () => {
+    console.log("Blur");
+  },
 };

--- a/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.tsx
+++ b/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.tsx
@@ -119,9 +119,20 @@ export type SingleSelectBaseProps = Omit<
     option: Nullable<SingleSelectOption>,
     meta: ActionMeta<SingleSelectOption>
   ) => void;
+
   required?: boolean | undefined;
   disabled?: boolean | undefined;
   readOnly?: boolean | undefined;
+
+  /**
+   * Event when select is focused
+   */
+  onFocus: Nullable<() => void>;
+
+  /**
+   * Event when select is blur
+   */
+  onBlur: Nullable<() => void>;
 };
 
 const SelectBase: React.FC<SingleSelectBaseProps> = (props) => {
@@ -137,6 +148,8 @@ const SelectBase: React.FC<SingleSelectBaseProps> = (props) => {
     error,
     description,
     onChange,
+    onFocus,
+    onBlur,
     disabled,
     readOnly,
     isClearable,
@@ -378,9 +391,14 @@ const SelectBase: React.FC<SingleSelectBaseProps> = (props) => {
             value={value}
             ref={selectRef}
             instanceId={instanceId}
-            openMenuOnFocus={true}
-            onFocus={() => setFocus(true)}
-            onBlur={() => setFocus(false)}
+            onFocus={() => {
+              if (onFocus) onFocus();
+              setFocus(true);
+            }}
+            onBlur={() => {
+              if (onBlur) onBlur();
+              setFocus(false);
+            }}
             menuPlacement={menuPlacement ? menuPlacement : "auto"}
             options={options}
             onChange={(selectedOption, meta) => {


### PR DESCRIPTION
In order to utilize focus and blur events to handle more corner cases of SingleSelect component. This commit exposes onBlur and onFocus event handlers as props
