### PR TITLE
feat: expand the functionality of getElementPosition to accept Element parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.126",
+  "version": "0.0.127",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,7 +5,9 @@ export type ElementPosition = {
   height: number;
 };
 
-export const getElementPosition = (element: HTMLElement): ElementPosition => {
+export const getElementPosition = (
+  element: HTMLElement | Element
+): ElementPosition => {
   const box = element.getBoundingClientRect();
 
   const body = document.body;


### PR DESCRIPTION
This commit accepts HTMLElement and Element as input props of getElementPosition to make it more versatile.