### PR TITLE
feat: expose loadingLabelText props at StatefulToggleField

### DIFF
--- a/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.stories.tsx
+++ b/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.stories.tsx
@@ -28,6 +28,7 @@ const Template: ComponentStory<typeof StatefulToggleField> = (args) => {
         state === "STATE_ERROR" ? "There is an error. Please try again." : null
       }
       state={state}
+      loadingLabelText="Loading..."
     />
   );
 };

--- a/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.tsx
+++ b/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.tsx
@@ -70,7 +70,10 @@ export type StatefulToggleFieldOptionalProps = Partial<
 >;
 
 export type StatefulToggleFieldProps = StatefulToggleFieldRequiredProps &
-  StatefulToggleFieldOptionalProps & { state: Nullable<State> };
+  StatefulToggleFieldOptionalProps & {
+    state: Nullable<State>;
+    loadingLabelText: string;
+  };
 
 export const statefulToggleFieldConfig: StatefulToggleFieldConfig = {
   focusHighlight: true,
@@ -121,7 +124,7 @@ const StatefulToggleField: React.FC<StatefulToggleFieldProps> = (props) => {
       label={props.label}
       additionalMessageOnLabel={
         props.state === "STATE_LOADING"
-          ? "Loading..."
+          ? props.loadingLabelText
           : props.additionalMessageOnLabel ?? null
       }
       description={props.description ?? ""}


### PR DESCRIPTION
Because

- We need a way to customize the loading label text of StatefulToggleField

This commit

- expose loadingLabelText props at StatefulToggleField
