### PR TITLE
fix: fix redundant react prop issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.132",
+  "version": "0.0.133",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.tsx
+++ b/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.tsx
@@ -115,16 +115,17 @@ export const statefulToggleFieldConfig: StatefulToggleFieldConfig = {
 };
 
 const StatefulToggleField: React.FC<StatefulToggleFieldProps> = (props) => {
+  const { loadingLabelText, ...remaingProps } = props;
   return (
     <ToggleFieldBase
-      {...props}
+      {...remaingProps}
       id={props.id}
       value={props.value}
       onChange={props.onChange}
       label={props.label}
       additionalMessageOnLabel={
         props.state === "STATE_LOADING"
-          ? props.loadingLabelText
+          ? loadingLabelText
           : props.additionalMessageOnLabel ?? null
       }
       description={props.description ?? ""}


### PR DESCRIPTION
Because

- In StateFulToggleField we use {...props} to spread the props but there had a prop "labelLoadingText" that won't be directly used as react component props. We need to catch it first. 

```js
{labelLoadingText, ...remaingProps} = props
```

This commit

- fix redundant react prop issue
