### PR TITLE
chore: rename Visual Data Preparation to Versatile Data Pipeline

### DIFF
--- a/src/ui/Accordion/AccordionBase/AccordionBase.stories.tsx
+++ b/src/ui/Accordion/AccordionBase/AccordionBase.stories.tsx
@@ -66,7 +66,7 @@ Playground.args = {
           <div className="flex flex-col p-5 bg-[#23C4E7] w-7/12">
             <div className="flex text-base text-white">
               An end-to-end workflow that automates a sequence of sub-components
-              to process visual data.
+              to process unstructured data.
             </div>
           </div>
         </div>
@@ -83,8 +83,8 @@ Playground.args = {
         <div className="bg-[#02D085] w-full">
           <div className="flex flex-col p-5 w-7/12">
             <div className="flex text-base text-white">
-              A data connector in charge of ingesting unstructured visual data
-              into a Pipeline.
+              A data connector in charge of ingesting unstructured data into a
+              Pipeline.
             </div>
           </div>
         </div>
@@ -101,8 +101,8 @@ Playground.args = {
         <div className="bg-[#DEC800] w-full">
           <div className="flex flex-col p-5 bg-[#DEC800] w-7/12">
             <div className="flex text-base text-white">
-              An algorithm that runs on unstructured visual data to solve a
-              certain Computer Vision (CV) Task.
+              An algorithm that runs on unstructured data to solve a specific AI
+              task.
             </div>
           </div>
         </div>
@@ -119,8 +119,8 @@ Playground.args = {
         <div className="bg-[#FF8A00] w-full">
           <div className="flex flex-col p-5 bg-[#FF8A00] w-7/12">
             <div className="flex text-base text-white">
-              A data connector to load the standarised CV Task output from Model
-              to the destination.
+              A data connector to load the standardised AI task output from
+              Model to the Destination.
             </div>
           </div>
         </div>

--- a/src/ui/Accordion/BasicAccordion/BasicAccordion.stories.tsx
+++ b/src/ui/Accordion/BasicAccordion/BasicAccordion.stories.tsx
@@ -33,7 +33,7 @@ Playground.args = {
           <div className="flex flex-col p-5 bg-[#23C4E7] w-full">
             <div className="flex text-base text-white">
               An end-to-end workflow that automates a sequence of sub-components
-              to process visual data.
+              to process unstructured data.
             </div>
           </div>
         </div>
@@ -49,8 +49,8 @@ Playground.args = {
         <div className="bg-[#02D085] w-full">
           <div className="flex flex-col p-5 w-full">
             <div className="flex text-base text-white">
-              A data connector in charge of ingesting unstructured visual data
-              into a Pipeline.
+              A data connector in charge of ingesting unstructured data into a
+              Pipeline.
             </div>
           </div>
         </div>
@@ -66,8 +66,8 @@ Playground.args = {
         <div className="bg-[#DEC800] w-full">
           <div className="flex flex-col p-5 bg-[#DEC800] w-full">
             <div className="flex text-base text-white">
-              An algorithm that runs on unstructured visual data to solve a
-              certain Computer Vision (CV) Task.
+              An algorithm that runs on unstructured data to solve a specific AI
+              task.
             </div>
           </div>
         </div>
@@ -83,8 +83,8 @@ Playground.args = {
         <div className="bg-[#FF8A00] w-full">
           <div className="flex flex-col p-5 bg-[#FF8A00] w-full">
             <div className="flex text-base text-white">
-              A data connector to load the standarised CV Task output from Model
-              to the destination.
+              A data connector to load the standardised AI task output from
+              Model to the Destination.
             </div>
           </div>
         </div>

--- a/src/ui/Accordion/BgIconAccordion/BgIconAccordion.stories.tsx
+++ b/src/ui/Accordion/BgIconAccordion/BgIconAccordion.stories.tsx
@@ -47,7 +47,7 @@ Playground.args = {
           <div className="flex flex-col p-5 w-7/12">
             <div className="flex text-base text-white">
               An end-to-end workflow that automates a sequence of sub-components
-              to process visual data.
+              to process unstructured data.
             </div>
           </div>
         </div>
@@ -64,8 +64,8 @@ Playground.args = {
         <div className="bg-[#285863] w-full">
           <div className="flex flex-col p-5 w-7/12">
             <div className="flex text-base text-white">
-              A data connector in charge of ingesting unstructured visual data
-              into a Pipeline.
+              A data connector in charge of ingesting unstructured data into a
+              Pipeline.
             </div>
           </div>
         </div>
@@ -82,8 +82,8 @@ Playground.args = {
         <div className="bg-[#285863] w-full">
           <div className="flex flex-col p-5 w-7/12">
             <div className="flex text-base text-white">
-              An algorithm that runs on unstructured visual data to solve a
-              certain Computer Vision (CV) Task.
+              An algorithm that runs on unstructured data to solve a specific AI
+              task.
             </div>
           </div>
         </div>
@@ -100,8 +100,8 @@ Playground.args = {
         <div className="bg-[#285863] w-full">
           <div className="flex flex-col p-5 w-7/12">
             <div className="flex text-base text-white">
-              A data connector to load the standarised CV Task output from Model
-              to the destination.
+              A data connector to load the standardised AI task output from
+              Model to the Destination.
             </div>
           </div>
         </div>


### PR DESCRIPTION
Because

- instead of Visual Data Preparation, VDP is Versatile Data Pipeline now. We realise that as a general ETL infrastructure, VDP is capable of processing all kinds of unstructured data, and we should not limit its usage to only visual data. That's why we replace the word Visual with Versatile. Besides, the term Data Preparation is a bit misleading, users often think it has something to do with data labelling or cleaning. The term Data Pipeline is definitely more precise to capture the core concept of VDP.

This commit

- update to Versatile Data Pipeline