### PR TITLE
fix: fix the TextArea missing description issue

### DIFF
--- a/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
+++ b/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
@@ -302,7 +302,12 @@ const TextAreaBase: React.FC<TextAreaBaseProps> = (props) => {
           { "mb-2.5": description }
         )}
         style={{
-          height: containerHeight ? `${containerHeight}px` : "",
+          height:
+            inputLabelType === "inset"
+              ? containerHeight
+                ? `${containerHeight}px`
+                : ""
+              : undefined,
           paddingTop:
             inputLabelType === "inset"
               ? containerPaddingTop


### PR DESCRIPTION
Because

- instill-ai/community#339 

This commit

-  remove redundant height in the TextArea to fix the TextArea missing description issue
- close instill-ai/community#339
