### PR TITLE
chore: update textarea bg color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.138",
+  "version": "0.0.140",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/ui/TextAreas/BasicTextArea/BasicTextArea.tsx
+++ b/src/ui/TextAreas/BasicTextArea/BasicTextArea.tsx
@@ -83,7 +83,7 @@ export const basicTextAreaConfig: BasicTextAreaConfig = {
   inputFontWeight: "font-normal",
   inputLineHeight: "",
   inputTextColor: "text-instillGrey95",
-  bgColor: "bg-white",
+  bgColor: "",
   inputBorderRadius: "rounded-[1px]",
   inputBorderColor: "border-instillGrey20",
   inputBorderStyle: "border-solid",

--- a/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
+++ b/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
@@ -360,7 +360,6 @@ const TextAreaBase: React.FC<TextAreaBaseProps> = (props) => {
               inputFontSize,
               inputFontWeight,
               inputLineHeight,
-              bgColor,
               placeholderFontFamily,
               placeholderFontSize,
               placeholderFontWeight,


### PR DESCRIPTION
Because

- instill-ai/community#335
- The bg color of TextArea should be transperant

This commit
- update textarea bg color
- close instill-ai/community#335
