### PR TITLE
fix: fix single select input padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.141-rc.0",
+  "version": "0.0.141-rc.1",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.140",
+  "version": "0.0.141-rc.0",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.141-rc.1",
+  "version": "0.0.141",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.tsx
+++ b/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.tsx
@@ -254,7 +254,7 @@ const SelectBase: React.FC<SingleSelectBaseProps> = (props) => {
       inputLabelType !== "inset"
     ) {
       setContainerHeight(70);
-      setInputValuePaddingTop(24);
+      setInputValuePaddingTop(0);
       setInputValuePaddingBottom(0);
       return;
     }


### PR DESCRIPTION
Because

- SingleSelect has wrong padding when at normal label mode

This commit

- fix single select input padding
- close instill-ai/community#337