### PR TITLE
feat: add getModelDefinitionToolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.141",
+  "version": "0.0.142",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/toolkits/getModelDefinitionToolkit.tsx
+++ b/src/toolkits/getModelDefinitionToolkit.tsx
@@ -1,0 +1,53 @@
+import cn from "clsx";
+import { IconStyle, IconStyleWithoutColor } from "../types/general";
+import {
+  ArtiVcIcon,
+  GitHubIcon,
+  HuggingFaceIcon,
+  LocalUploadIcon,
+} from "../ui";
+
+export const getModelDefinitionToolkit = (modelDefinition: string) => {
+  switch (modelDefinition) {
+    case "model-definitions/github": {
+      return {
+        getIcon: (iconStyle: IconStyle) => <GitHubIcon {...iconStyle} />,
+        title: "GitHub",
+      };
+    }
+
+    case "model-definitions/local": {
+      return {
+        getIcon: (iconStyle: IconStyle) => <LocalUploadIcon {...iconStyle} />,
+        title: "Local",
+      };
+    }
+
+    case "model-definitions/artivc": {
+      return {
+        getIcon: (iconStyle: IconStyleWithoutColor) => (
+          <ArtiVcIcon {...iconStyle} />
+        ),
+        title: "ArtiVC",
+      };
+    }
+
+    case "model-definitions/huggingface": {
+      return {
+        getIcon: (iconStyle: IconStyleWithoutColor) => (
+          <HuggingFaceIcon {...iconStyle} />
+        ),
+        title: "Hugging Face",
+      };
+    }
+
+    default: {
+      return {
+        getIcon: (iconStyle: IconStyle) => {
+          return <div className={cn(iconStyle.width, iconStyle.height)} />;
+        },
+        title: "",
+      };
+    }
+  }
+};

--- a/src/toolkits/index.ts
+++ b/src/toolkits/index.ts
@@ -1,1 +1,2 @@
 export { getModelInstanceTaskToolkit } from "./getModelInstanceTaskToolkit";
+export { getModelDefinitionToolkit } from "./getModelDefinitionToolkit";

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -386,3 +386,5 @@ export type IconStyle = {
   position?: string;
   color?: string;
 };
+
+export type IconStyleWithoutColor = Omit<IconStyle, "color">;


### PR DESCRIPTION
Because

- We want to centralize some ui component related toolkit into design-system

This commit

- add getModelDefinitionToolkit
