### PR TITLE
feat: getPipelineModeToolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/design-system",
-  "version": "0.0.142",
+  "version": "0.0.143",
   "description": "Instill AI's design system",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/src/toolkits/getPipelineModeToolkit.tsx
+++ b/src/toolkits/getPipelineModeToolkit.tsx
@@ -1,0 +1,25 @@
+import cn from "clsx";
+import { IconStyle, PipelineMode } from "../types/general";
+import { AsyncIcon, SyncIcon } from "../ui";
+
+export const getPipelineModeToolkit = (mode: PipelineMode) => {
+  switch (mode) {
+    case "MODE_ASYNC":
+      return {
+        getIcon: (iconStyle: IconStyle) => <AsyncIcon {...iconStyle} />,
+        label: "Async",
+      };
+    case "MODE_SYNC":
+      return {
+        getIcon: (iconStyle: IconStyle) => <SyncIcon {...iconStyle} />,
+        label: "Sync",
+      };
+    default:
+      return {
+        getIcon: (iconStyle: IconStyle) => {
+          return <div className={cn(iconStyle.width, iconStyle.height)} />;
+        },
+        label: "",
+      };
+  }
+};

--- a/src/toolkits/index.ts
+++ b/src/toolkits/index.ts
@@ -1,2 +1,3 @@
 export { getModelInstanceTaskToolkit } from "./getModelInstanceTaskToolkit";
 export { getModelDefinitionToolkit } from "./getModelDefinitionToolkit";
+export { getPipelineModeToolkit } from "./getPipelineModeToolkit";

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -387,4 +387,6 @@ export type IconStyle = {
   color?: string;
 };
 
+export type PipelineMode = "MODE_UNSPECIFIED" | "MODE_SYNC" | "MODE_ASYNC";
+
 export type IconStyleWithoutColor = Omit<IconStyle, "color">;


### PR DESCRIPTION
Because

- We want to centralize some ui component related toolkit into design-system

This commit

- add getPipelineModeToolkit

