### PR TITLE
feat: update package config

### DIFF
--- a/.changeset/lovely-files-taste.md
+++ b/.changeset/lovely-files-taste.md
@@ -1,0 +1,5 @@
+---
+"@instill-ai/design-system": patch
+---
+
+Update the package.json config to make it public

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -107,5 +107,8 @@
   "engines": {
     "node": ">=14.6.0"
   },
-  "packageManager": "pnpm@7.5.0"
+  "packageManager": "pnpm@7.5.0",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
Because

- The npm publish encounters private lib not allowed issue

This commit

- update package config to let npm know this is public lib