### PR TITLE
fix: fix toolkit package config

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -37,5 +37,8 @@
     "axios": "^1.3.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Because

- package toolkit's package config is wrong which cause error when publish to npm registry

This commit

-  fix toolkit package config
