### PR TITLE
feat: add canEdit field into configurePipelineFormSchema

### DIFF
--- a/packages/toolkit/src/store/useConfigurePipelineFormStore.ts
+++ b/packages/toolkit/src/store/useConfigurePipelineFormStore.ts
@@ -5,6 +5,7 @@ import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
 export const configurePipelineFormSchema = z.object({
+  canEdit: z.boolean(),
   pipelineDescription: z.nullable(z.string()),
 });
 
@@ -41,9 +42,11 @@ export const configurePipelineFormInitialState: ConfigurePipelineFormState = {
   formIsDirty: false,
   fields: {
     pipelineDescription: null,
+    canEdit: false,
   },
   errors: {
     pipelineDescription: null,
+    canEdit: null,
   },
 };
 


### PR DESCRIPTION
Because

- the configurePipelineFormSchema need a field to represent the edit status

This commit

- add canEdit field into configurePipelineFormSchema
