### PR TITLE
fix: fix hook export path

### DIFF
--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -7,3 +7,4 @@ export * from "./store";
 export * from "./react-query-service";
 export * from "./amplitude";
 export * from "./context";
+export * from "./hook";


### PR DESCRIPTION
Because

- the hook export path is wrong

This commit

- fix hook export path
