### PR TITLE
fix: fix useMessageBoxStore export path

### DIFF
--- a/packages/toolkit/src/store/index.ts
+++ b/packages/toolkit/src/store/index.ts
@@ -1,5 +1,6 @@
 export * from "./useConfigureModelFormStore";
 export * from "./useConfigurePipelineFormStore";
 export * from "./useConfigureProfileFormStore";
+export * from "./useMessageBoxStore";
 export * from "./useModalStore";
 export * from "./useResourceFormStore";

--- a/packages/toolkit/src/store/useMessageBoxStore.tsx
+++ b/packages/toolkit/src/store/useMessageBoxStore.tsx
@@ -28,7 +28,7 @@ export const messageBoxInitialState: MessageBoxState = {
   activate: false,
 };
 
-export const useConfigureModelFormStore = create<MessageBoxStore>()(
+export const useMessageBoxStore = create<MessageBoxStore>()(
   devtools((set) => ({
     ...messageBoxInitialState,
     init: () => set(messageBoxInitialState),


### PR DESCRIPTION
Because

- the export path of useMessageBoxStore is wrong
- the variable name of useMessageBoxStore is wrong

This commit

- fix useMessageBoxStore export path and variable name
