### PR TITLE
feat: replace the props of ProgressMessageBoxBase from setState to setActivate

### DIFF
--- a/packages/design-system/src/ui/ProgressMessageBoxs/BasicProgressMessageBox/BasicProgressMessageBox.stories.tsx
+++ b/packages/design-system/src/ui/ProgressMessageBoxs/BasicProgressMessageBox/BasicProgressMessageBox.stories.tsx
@@ -34,7 +34,9 @@ const Template: StoryFn<typeof BasicProgressMessageBox> = (args) => {
       <BasicProgressMessageBox
         {...args}
         state={messageBoxState}
-        setState={setMessageBoxState}
+        setActivate={(activate) =>
+          setMessageBoxState((prev) => ({ ...prev, activate }))
+        }
       />
     </>
   );

--- a/packages/design-system/src/ui/ProgressMessageBoxs/BasicProgressMessageBox/BasicProgressMessageBox.tsx
+++ b/packages/design-system/src/ui/ProgressMessageBoxs/BasicProgressMessageBox/BasicProgressMessageBox.tsx
@@ -57,12 +57,12 @@ export const basicProgressMessageBoxConfig: BasicProgressMessageBoxConfig = {
 const BasicProgressMessageBox: React.FC<BasicProgressMessageBoxProps> = (
   props
 ) => {
-  const { state, setState, closable, width } = props;
+  const { state, setActivate, closable, width } = props;
 
   return (
     <ProgressMessageBoxBase
       state={state}
-      setState={setState}
+      setActivate={setActivate}
       closable={closable}
       width={width}
       {...basicProgressMessageBoxConfig}

--- a/packages/design-system/src/ui/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.stories.tsx
+++ b/packages/design-system/src/ui/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.stories.tsx
@@ -36,7 +36,9 @@ const Template: StoryFn<typeof ProgressMessageBoxBase> = (args) => {
       <ProgressMessageBoxBase
         {...args}
         state={messageBoxState}
-        setState={setMessageBoxState}
+        setActivate={(activate) =>
+          setMessageBoxState((prev) => ({ ...prev, activate }))
+        }
       />
     </>
   );

--- a/packages/design-system/src/ui/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.tsx
+++ b/packages/design-system/src/ui/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.tsx
@@ -125,7 +125,7 @@ export type ProgressMessageBoxBaseProps = {
 
   state: ProgressMessageBoxState;
 
-  setState: Dispatch<SetStateAction<ProgressMessageBoxState>>;
+  setActivate: (activate: boolean) => void;
 };
 
 const ProgressMessageBoxBase: React.FC<ProgressMessageBoxBaseProps> = (
@@ -133,7 +133,7 @@ const ProgressMessageBoxBase: React.FC<ProgressMessageBoxBaseProps> = (
 ) => {
   const {
     state,
-    setState,
+    setActivate,
     width,
     errorIconColor,
     errorIconWidth,
@@ -243,12 +243,7 @@ const ProgressMessageBoxBase: React.FC<ProgressMessageBoxBaseProps> = (
             </div>
             {closable ? (
               <button
-                onClick={() =>
-                  setState((prev) => ({
-                    ...prev,
-                    activate: false,
-                  }))
-                }
+                onClick={() => setActivate(false)}
                 className="flex mb-auto"
               >
                 <XIcon


### PR DESCRIPTION
Because

- setState is too generic, we want to be as specific as possible

This commit

- replace the props of ProgressMessageBoxBase from setState to setActivate
