### PR TITLE
feat: make the export path of toolkit simple

### DIFF
--- a/packages/toolkit/esbuild.js
+++ b/packages/toolkit/esbuild.js
@@ -2,7 +2,7 @@ const esbuild = require("esbuild");
 const { peerDependencies } = require("./package.json");
 
 const sharedConfig = {
-  entryPoints: ["./src/lib/index.ts", "./src/view/index.ts", "./src/index.ts"],
+  entryPoints: ["./src/index.ts"],
   bundle: true,
   minify: true,
   sourcemap: true,

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -17,20 +17,7 @@
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx --cache"
   },
   "main": "./build/cjs/index.js",
-  "exports": {
-    ".": {
-      "import": "./build/esm/index.js",
-      "require": "./build/cjs/index.js"
-    },
-    "./lib": {
-      "import": "./build/esm/lib/index.js",
-      "require": "./build/cjs/lib/index.js"
-    },
-    "./view": {
-      "import": "./build/esm/view/index.js",
-      "require": "./build/cjs/view/index.js"
-    }
-  },
+  "module": "./build/esm/index.js",
   "files": [
     "build"
   ],


### PR DESCRIPTION
Because

- We leave the code spilt later

This commit

- make the export path of toolkit simple
