### PR TITLE
fix: fix how we build our package

### DIFF
--- a/packages/toolkit/esbuild.js
+++ b/packages/toolkit/esbuild.js
@@ -8,14 +8,13 @@ const sharedConfig = {
   sourcemap: true,
   target: "esnext",
   external: Object.keys(peerDependencies),
-  platform: "node",
 };
 
 esbuild
   .build({
     ...sharedConfig,
     format: "esm",
-    outdir: "./build/esm",
+    outfile: "./build/index.esm.js",
     target: ["esnext", "node12"],
   })
   .catch(() => process.exit(1));
@@ -24,7 +23,7 @@ esbuild
   .build({
     ...sharedConfig,
     format: "cjs",
-    outdir: "./build/cjs",
+    outfile: "./build/index.cjs.js",
     target: ["esnext", "node12"],
   })
   .catch(() => process.exit(1));

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -16,12 +16,12 @@
     "ts-types": "tsc --emitDeclarationOnly",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx --cache"
   },
-  "main": "./build/cjs/index.js",
-  "module": "./build/esm/index.js",
+  "main": "build/index.cjs.js",
+  "module": "build/index.esm.js",
+  "typings": "build/index.d.ts",
   "files": [
     "build"
   ],
-  "types": "./build/types/index.d.ts",
   "license": "Apache-2.0",
   "private": false,
   "devDependencies": {

--- a/packages/toolkit/tsconfig.json
+++ b/packages/toolkit/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "build/types"
+    "outDir": "build"
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["./testRunner.ts"]


### PR DESCRIPTION
Because

- how we build `toolkit` may be wrong

This commit

- fix how we build our package
