### PR TITLE
fix: fix design-system export path

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -25,7 +25,7 @@
     "build": "pnpm rimraf build && node ./esbuild.js && pnpm ts-types",
     "test": "jest"
   },
-  "module": "build/index.esm.js",
+  "module": "build/index.js",
   "typings": "build/index.d.ts",
   "files": [
     "build"


### PR DESCRIPTION
Because

- the export path of design system is wrong

This commit

- fix design-system export path