### PR TITLE
fix: fix wrong export name of ChangeModelInstanceStateToggle

### DIFF
--- a/packages/toolkit/src/view/model/ChangeModelInstanceStateToggle.tsx
+++ b/packages/toolkit/src/view/model/ChangeModelInstanceStateToggle.tsx
@@ -6,7 +6,7 @@ import { UseMutationResult } from "@tanstack/react-query";
 
 import { ModelInstance, Nullable, Operation } from "../../lib";
 
-export type ChangeResourceStateButtonProps = {
+export type ChangeModelInstanceStateToggleProps = {
   modelInstance: Nullable<ModelInstance>;
   switchOff: UseMutationResult<
     { modelInstance: ModelInstance; operation: Operation },
@@ -30,13 +30,9 @@ export type ChangeResourceStateButtonProps = {
   accessToken: Nullable<string>;
 };
 
-export const ChangeResourceStateButton: FC<ChangeResourceStateButtonProps> = ({
-  modelInstance,
-  switchOn,
-  switchOff,
-  marginBottom,
-  accessToken,
-}) => {
+export const ChangeModelInstanceStateToggle: FC<
+  ChangeModelInstanceStateToggleProps
+> = ({ modelInstance, switchOn, switchOff, marginBottom, accessToken }) => {
   const [error, setError] = useState<Nullable<string>>(null);
 
   useEffect(() => {


### PR DESCRIPTION
Because

- the export name ChangeModelInstanceStateToggle is wrong

This commit

- fix wrong export name of ChangeModelInstanceStateToggle
