### PR TITLE
fix: fix wrong label UI when its value is null

### DIFF
--- a/packages/design-system/src/ui/InputLabels/InputLabelBase/InputLabelBase.tsx
+++ b/packages/design-system/src/ui/InputLabels/InputLabelBase/InputLabelBase.tsx
@@ -142,26 +142,28 @@ const InputLabelBase = React.forwardRef<InputLabelBaseRef, InputLabelBaseProps>(
             className="z-10 flex flex-row gap-x-2 w-full"
             htmlFor={htmlFor}
           >
-            <p
-              className={cn(
-                "flex-shrink-0",
-                error
-                  ? cn(
-                      errorLabelFontFamily,
-                      errorLabelFontSize,
-                      errorLabelFontWeight,
-                      errorLabelLineHeight,
-                      errorLabelTextColor
-                    )
-                  : cn(
-                      labelFontSize,
-                      labelFontWeight,
-                      labelTextColor,
-                      labelFontFamily,
-                      labelLineHeight
-                    )
-              )}
-            >{`${label} ${required ? "*" : ""}`}</p>
+            {label ? (
+              <p
+                className={cn(
+                  "flex-shrink-0",
+                  error
+                    ? cn(
+                        errorLabelFontFamily,
+                        errorLabelFontSize,
+                        errorLabelFontWeight,
+                        errorLabelLineHeight,
+                        errorLabelTextColor
+                      )
+                    : cn(
+                        labelFontSize,
+                        labelFontWeight,
+                        labelTextColor,
+                        labelFontFamily,
+                        labelLineHeight
+                      )
+                )}
+              >{`${label} ${required ? "*" : ""}`}</p>
+            ) : null}
             <p
               className={cn(
                 "my-auto",


### PR DESCRIPTION
Because

- The label should be null when its value is null

This commit

- fix wrong label UI when its value is null
