### PR TITLE
fix: fix unnecessary gap when the label value is null

### DIFF
--- a/packages/design-system/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.tsx
+++ b/packages/design-system/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.tsx
@@ -269,33 +269,35 @@ const SelectBase: React.FC<SingleSelectBaseProps> = (props) => {
   return (
     <div className="flex flex-col">
       <div
-        className={cn("flex flex-col gap-y-2.5 relative", {
+        className={cn("flex flex-col relative", {
           "mb-2.5": description,
         })}
       >
-        <InputLabelBase
-          label={label}
-          message={additionalMessageOnLabel}
-          required={required}
-          htmlFor={id}
-          type={inputLabelType}
-          labelFontFamily={labelFontFamily}
-          labelFontSize={labelFontSize}
-          labelFontWeight={labelFontWeight}
-          labelLineHeight={labelLineHeight}
-          labelTextColor={labelTextColor}
-          error={error}
-          errorLabelFontFamily={errorLabelFontFamily}
-          errorLabelFontSize={errorLabelFontSize}
-          errorLabelFontWeight={errorLabelFontWeight}
-          errorLabelLineHeight={errorLabelLineHeight}
-          errorLabelTextColor={errorLabelTextColor}
-          messageFontFamily={messageFontFamily}
-          messageFontSize={messageFontSize}
-          messageFontWeight={messageFontWeight}
-          messageLineHeight={messageLineHeight}
-          messageTextColor={messageTextColor}
-        />
+        <div className={label ? "mb-2.5" : ""}>
+          <InputLabelBase
+            label={label}
+            message={additionalMessageOnLabel}
+            required={required}
+            htmlFor={id}
+            type={inputLabelType}
+            labelFontFamily={labelFontFamily}
+            labelFontSize={labelFontSize}
+            labelFontWeight={labelFontWeight}
+            labelLineHeight={labelLineHeight}
+            labelTextColor={labelTextColor}
+            error={error}
+            errorLabelFontFamily={errorLabelFontFamily}
+            errorLabelFontSize={errorLabelFontSize}
+            errorLabelFontWeight={errorLabelFontWeight}
+            errorLabelLineHeight={errorLabelLineHeight}
+            errorLabelTextColor={errorLabelTextColor}
+            messageFontFamily={messageFontFamily}
+            messageFontSize={messageFontSize}
+            messageFontWeight={messageFontWeight}
+            messageLineHeight={messageLineHeight}
+            messageTextColor={messageTextColor}
+          />
+        </div>
         <div>
           <ReactSelect
             id={id}

--- a/packages/design-system/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
+++ b/packages/design-system/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
@@ -207,37 +207,39 @@ const TextAreaBase: React.FC<TextAreaBaseProps> = (props) => {
     <div className="flex flex-col">
       <div
         className={cn(
-          "flex flex-col gap-y-2.5 relative",
+          "flex flex-col relative",
           inputWidth,
           inputBorderRadius,
           bgColor,
           { "mb-2.5": description }
         )}
       >
-        <InputLabelBase
-          ref={inputLabelRef}
-          label={label}
-          message={additionalMessageOnLabel}
-          error={error}
-          required={required}
-          htmlFor={id}
-          type={inputLabelType}
-          labelFontFamily={labelFontFamily}
-          labelFontSize={labelFontSize}
-          labelFontWeight={labelFontWeight}
-          labelLineHeight={labelLineHeight}
-          labelTextColor={labelTextColor}
-          errorLabelFontFamily={errorLabelFontFamily}
-          errorLabelFontSize={errorLabelFontSize}
-          errorLabelFontWeight={errorLabelFontWeight}
-          errorLabelLineHeight={errorLabelLineHeight}
-          errorLabelTextColor={errorLabelTextColor}
-          messageFontFamily={messageFontFamily}
-          messageFontSize={messageFontSize}
-          messageFontWeight={messageFontWeight}
-          messageLineHeight={messageLineHeight}
-          messageTextColor={messageTextColor}
-        />
+        <div className={label ? "mb-2.5" : ""}>
+          <InputLabelBase
+            ref={inputLabelRef}
+            label={label}
+            message={additionalMessageOnLabel}
+            error={error}
+            required={required}
+            htmlFor={id}
+            type={inputLabelType}
+            labelFontFamily={labelFontFamily}
+            labelFontSize={labelFontSize}
+            labelFontWeight={labelFontWeight}
+            labelLineHeight={labelLineHeight}
+            labelTextColor={labelTextColor}
+            errorLabelFontFamily={errorLabelFontFamily}
+            errorLabelFontSize={errorLabelFontSize}
+            errorLabelFontWeight={errorLabelFontWeight}
+            errorLabelLineHeight={errorLabelLineHeight}
+            errorLabelTextColor={errorLabelTextColor}
+            messageFontFamily={messageFontFamily}
+            messageFontSize={messageFontSize}
+            messageFontWeight={messageFontWeight}
+            messageLineHeight={messageLineHeight}
+            messageTextColor={messageTextColor}
+          />
+        </div>
         <div className="flex relative">
           <textarea
             {...passThrough}

--- a/packages/design-system/src/ui/TextFields/TextFieldBase/TextFieldBase.tsx
+++ b/packages/design-system/src/ui/TextFields/TextFieldBase/TextFieldBase.tsx
@@ -147,37 +147,36 @@ const TextFieldBase: React.FC<TextFieldBaseProps> = (props) => {
   return (
     <div className="flex flex-col">
       <div
-        className={cn(
-          "flex flex-col gap-y-2.5 relative",
-          inputWidth,
-          inputBorderRadius,
-          { "mb-2.5": description }
-        )}
+        className={cn("flex flex-col relative", inputWidth, inputBorderRadius, {
+          "mb-2.5": description,
+        })}
       >
-        <InputLabelBase
-          ref={inputLabelRef}
-          error={error}
-          message={additionalMessageOnLabel}
-          required={required}
-          htmlFor={id}
-          type={inputLabelType}
-          label={label}
-          labelFontFamily={labelFontFamily}
-          labelFontSize={labelFontSize}
-          labelFontWeight={labelFontWeight}
-          labelLineHeight={labelLineHeight}
-          labelTextColor={labelTextColor}
-          errorLabelFontFamily={errorLabelFontFamily}
-          errorLabelFontSize={errorLabelFontSize}
-          errorLabelFontWeight={errorLabelFontWeight}
-          errorLabelLineHeight={errorLabelLineHeight}
-          errorLabelTextColor={errorLabelTextColor}
-          messageFontFamily={messageFontFamily}
-          messageFontSize={messageFontSize}
-          messageFontWeight={messageFontWeight}
-          messageLineHeight={messageLineHeight}
-          messageTextColor={messageTextColor}
-        />
+        <div className={label ? "mb-2.5" : ""}>
+          <InputLabelBase
+            ref={inputLabelRef}
+            error={error}
+            message={additionalMessageOnLabel}
+            required={required}
+            htmlFor={id}
+            type={inputLabelType}
+            label={label}
+            labelFontFamily={labelFontFamily}
+            labelFontSize={labelFontSize}
+            labelFontWeight={labelFontWeight}
+            labelLineHeight={labelLineHeight}
+            labelTextColor={labelTextColor}
+            errorLabelFontFamily={errorLabelFontFamily}
+            errorLabelFontSize={errorLabelFontSize}
+            errorLabelFontWeight={errorLabelFontWeight}
+            errorLabelLineHeight={errorLabelLineHeight}
+            errorLabelTextColor={errorLabelTextColor}
+            messageFontFamily={messageFontFamily}
+            messageFontSize={messageFontSize}
+            messageFontWeight={messageFontWeight}
+            messageLineHeight={messageLineHeight}
+            messageTextColor={messageTextColor}
+          />
+        </div>
         <div className="flex relative">
           <input
             {...passThrough}

--- a/packages/design-system/src/ui/ToggleFields/ToggleFieldBase/ToggleFieldBase.tsx
+++ b/packages/design-system/src/ui/ToggleFields/ToggleFieldBase/ToggleFieldBase.tsx
@@ -175,30 +175,32 @@ const ToggleFieldBase: React.FC<ToggleFieldBaseProps> = (props) => {
 
   return (
     <div className="flex flex-col">
-      <div className={cn("flex flex-col gap-y-2.5", { "mb-2.5": description })}>
-        <InputLabelBase
-          message={additionalMessageOnLabel}
-          messageFontFamily={messageFontFamily}
-          messageFontSize={messageFontSize}
-          messageFontWeight={messageFontWeight}
-          messageLineHeight={messageLineHeight}
-          messageTextColor={messageTextColor}
-          required={required}
-          htmlFor={`${id}-label`}
-          type="normal"
-          label={label}
-          labelFontFamily={labelFontFamily}
-          labelFontSize={labelFontSize}
-          labelFontWeight={labelFontWeight}
-          labelLineHeight={labelLineHeight}
-          labelTextColor={labelTextColor}
-          error={error}
-          errorLabelFontFamily={errorLabelFontFamily}
-          errorLabelFontSize={errorLabelFontSize}
-          errorLabelFontWeight={errorLabelFontWeight}
-          errorLabelLineHeight={errorLabelLineHeight}
-          errorLabelTextColor={errorLabelTextColor}
-        />
+      <div className={cn("flex flex-col", { "mb-2.5": description })}>
+        <div className={label ? "mb-2.5" : ""}>
+          <InputLabelBase
+            message={additionalMessageOnLabel}
+            messageFontFamily={messageFontFamily}
+            messageFontSize={messageFontSize}
+            messageFontWeight={messageFontWeight}
+            messageLineHeight={messageLineHeight}
+            messageTextColor={messageTextColor}
+            required={required}
+            htmlFor={`${id}-label`}
+            type="normal"
+            label={label}
+            labelFontFamily={labelFontFamily}
+            labelFontSize={labelFontSize}
+            labelFontWeight={labelFontWeight}
+            labelLineHeight={labelLineHeight}
+            labelTextColor={labelTextColor}
+            error={error}
+            errorLabelFontFamily={errorLabelFontFamily}
+            errorLabelFontSize={errorLabelFontSize}
+            errorLabelFontWeight={errorLabelFontWeight}
+            errorLabelLineHeight={errorLabelLineHeight}
+            errorLabelTextColor={errorLabelTextColor}
+          />
+        </div>
         <label
           htmlFor={id}
           className={cn("flex relative w-[90px] h-10", inputBgColor)}

--- a/packages/design-system/src/ui/UploadFileFields/UploadFileFieldBase/UploadFileFieldBase.tsx
+++ b/packages/design-system/src/ui/UploadFileFields/UploadFileFieldBase/UploadFileFieldBase.tsx
@@ -193,33 +193,35 @@ const UploadFileFieldBase: React.FC<UploadFileFieldBaseProps> = (props) => {
   return (
     <div className="flex flex-col">
       <div
-        className={cn("relative flex flex-col gap-y-2.5 group", {
+        className={cn("relative flex flex-col group", {
           "mb-2.5": description,
         })}
       >
-        <InputLabelBase
-          message={additionalMessageOnLabel}
-          required={required}
-          htmlFor={id}
-          type={inputLabelType}
-          label={label}
-          error={error}
-          labelFontFamily={labelFontFamily}
-          labelFontSize={labelFontSize}
-          labelFontWeight={labelFontWeight}
-          labelLineHeight={labelLineHeight}
-          labelTextColor={labelTextColor}
-          errorLabelFontFamily={errorLabelFontFamily}
-          errorLabelFontSize={errorLabelFontSize}
-          errorLabelFontWeight={errorLabelFontWeight}
-          errorLabelLineHeight={errorLabelLineHeight}
-          errorLabelTextColor={errorLabelTextColor}
-          messageFontFamily={messageFontFamily}
-          messageFontSize={messageFontSize}
-          messageFontWeight={messageFontWeight}
-          messageLineHeight={messageLineHeight}
-          messageTextColor={messageTextColor}
-        />
+        <div className={label ? "mb-2.5" : ""}>
+          <InputLabelBase
+            message={additionalMessageOnLabel}
+            required={required}
+            htmlFor={id}
+            type={inputLabelType}
+            label={label}
+            error={error}
+            labelFontFamily={labelFontFamily}
+            labelFontSize={labelFontSize}
+            labelFontWeight={labelFontWeight}
+            labelLineHeight={labelLineHeight}
+            labelTextColor={labelTextColor}
+            errorLabelFontFamily={errorLabelFontFamily}
+            errorLabelFontSize={errorLabelFontSize}
+            errorLabelFontWeight={errorLabelFontWeight}
+            errorLabelLineHeight={errorLabelLineHeight}
+            errorLabelTextColor={errorLabelTextColor}
+            messageFontFamily={messageFontFamily}
+            messageFontSize={messageFontSize}
+            messageFontWeight={messageFontWeight}
+            messageLineHeight={messageLineHeight}
+            messageTextColor={messageTextColor}
+          />
+        </div>
         <label
           htmlFor={id}
           className={cn(


### PR DESCRIPTION
Because

- the InputField had unnecessary gap between the label and the input when the label's value is null

This commit

- fix unnecessary gap when the label value is null
