### PR TITLE
fix: fix design-system tsconfig didn't exclude test related file

### DIFF
--- a/packages/design-system/.eslintrc.cjs
+++ b/packages/design-system/.eslintrc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
   root: true,
   extends: ["@instill-ai/eslint-config-cortex"],
-  ignorePatterns: ["esbuild.js"],
+  ignorePatterns: ["esbuild.js", "setupTests.ts", "vitest.config.ts"],
 };

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "outDir": "build"
   },
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["./setupTests.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
Because

- design-system tsconfig didn't exclude test related file

This commit

- fix design-system tsconfig didn't exclude test related file
