### PR TITLE
fix: fix apiRoute type export path

### DIFF
--- a/packages/toolkit/src/lib/type/index.ts
+++ b/packages/toolkit/src/lib/type/index.ts
@@ -1,1 +1,2 @@
 export * from "./general";
+export * from "./apiRoute";


### PR DESCRIPTION
Because

- apiRoute export type is wrong

This commit

- fix apiRoute type export path