### PR TITLE
fix: remove exports property in package.json

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -32,16 +32,6 @@
   "files": [
     "dist"
   ],
-  "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    },
-    "./dist/index.css": {
-      "import": "./dist/index.css",
-      "require": "./dist/index.css"
-    }
-  },
   "devDependencies": {
     "@babel/core": "^7.17.8",
     "@babel/preset-env": "^7.16.11",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -22,12 +22,6 @@
   "files": [
     "dist"
   ],
-  "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    }
-  },
   "license": "Apache-2.0",
   "private": false,
   "devDependencies": {


### PR DESCRIPTION
Because

- exports property in package.json is troublesome

This commit

- remove exports property in package.json
