### PR TITLE
feat: digest user in configure profile form

### DIFF
--- a/packages/toolkit/src/lib/store/useConfigureProfileFormStore.tsx
+++ b/packages/toolkit/src/lib/store/useConfigureProfileFormStore.tsx
@@ -15,7 +15,7 @@ export const configureProfileFormFieldSchema = z.object({
   userName: z.nullable(z.string()),
   orgName: z.nullable(z.string()),
   role: z.nullable(z.string()),
-  newsletterSubscription: z.boolean(),
+  newsletterSubscription: z.nullable(z.boolean()),
 });
 
 /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
@@ -75,7 +75,7 @@ export const configureProfileFormInitialState: ConfigureProfileFormState = {
     userName: null,
     orgName: null,
     role: null,
-    newsletterSubscription: true,
+    newsletterSubscription: null,
   },
   errors: {
     firstName: null,

--- a/packages/toolkit/src/lib/vdp-sdk/mgmt/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/mgmt/types.ts
@@ -3,13 +3,14 @@ export type User = {
   uid: string;
   email: string;
   id: string;
-  company_name: string;
+  first_name: string;
+  last_name: string;
+  customer_id: string;
+  org_name: string;
   role: string;
-  usage_data_collection: boolean;
   newsletter_subscription: boolean;
   type: string;
   create_time: string;
   update_time: string;
   cookie_token?: string;
-  plan: string;
 };

--- a/packages/toolkit/src/view/mgmt/ConfigureProfileForm/ConfigureProfileControl.tsx
+++ b/packages/toolkit/src/view/mgmt/ConfigureProfileForm/ConfigureProfileControl.tsx
@@ -1,10 +1,10 @@
+import { z } from "zod";
+import { OutlineButton, SolidButton } from "@instill-ai/design-system";
 import {
   useConfigureProfileFormStore,
   validateConfigureProfileFormFieldSchema,
   type ConfigureProfileFormState,
 } from "../../../lib";
-import { OutlineButton, SolidButton } from "@instill-ai/design-system";
-import { z } from "zod";
 
 export const ConfigureProfileControl = () => {
   const fields = useConfigureProfileFormStore((state) => state.fields);

--- a/packages/toolkit/src/view/mgmt/ConfigureProfileForm/ConfigureProfileForm.tsx
+++ b/packages/toolkit/src/view/mgmt/ConfigureProfileForm/ConfigureProfileForm.tsx
@@ -1,4 +1,4 @@
-import type { Nullable } from "../../../lib";
+import type { Nullable, User } from "../../../lib";
 import { FirstNameField } from "./FirstNameField";
 import { LastNameField } from "./LastNameField";
 import { OrgNameField } from "./OrgNameField";
@@ -9,16 +9,15 @@ import { NewsletterSubscriptionField } from "./NewsletterSubscriptionField";
 import { ConfigureProfileControl } from "./ConfigureProfileControl";
 
 export type ConfigureProfileFormProps = {
+  user: Nullable<User>;
   marginBottom: Nullable<string>;
   roles: SingleSelectOption[];
   width: Nullable<string>;
 };
 
-export const ConfigureProfileForm = ({
-  marginBottom,
-  roles,
-  width,
-}: ConfigureProfileFormProps) => {
+export const ConfigureProfileForm = (props: ConfigureProfileFormProps) => {
+  const { user, marginBottom, roles, width } = props;
+
   return (
     <FormRoot marginBottom={marginBottom} formLess={false} width={width}>
       <div className="mb-6 flex flex-row py-10">
@@ -26,13 +25,13 @@ export const ConfigureProfileForm = ({
       </div>
       <div className="mb-8 flex flex-col gap-y-6">
         <div className="flex flex-row gap-x-6">
-          <FirstNameField />
-          <LastNameField />
+          <FirstNameField user={user} />
+          <LastNameField user={user} />
         </div>
-        <UserNameField />
-        <OrgNameField />
-        <RoleField roles={roles} />
-        <NewsletterSubscriptionField />
+        <UserNameField user={user} />
+        <OrgNameField user={user} />
+        <RoleField roles={roles} user={user} />
+        <NewsletterSubscriptionField user={user} />
       </div>
       <ConfigureProfileControl />
     </FormRoot>

--- a/packages/toolkit/src/view/mgmt/ConfigureProfileForm/FirstNameField.tsx
+++ b/packages/toolkit/src/view/mgmt/ConfigureProfileForm/FirstNameField.tsx
@@ -1,10 +1,12 @@
 import { ChangeEvent } from "react";
-import {
-  useConfigureProfileFormStore,
-  type ConfigureProfileFormStore,
-} from "../../../lib";
 import { BasicTextField } from "@instill-ai/design-system";
 import { shallow } from "zustand/shallow";
+import {
+  useConfigureProfileFormStore,
+  type Nullable,
+  type User,
+  type ConfigureProfileFormStore,
+} from "../../../lib";
 
 const selector = (state: ConfigureProfileFormStore) => ({
   firstName: state.fields.firstName,
@@ -12,7 +14,12 @@ const selector = (state: ConfigureProfileFormStore) => ({
   firstNameError: state.errors.firstName,
 });
 
-export const FirstNameField = () => {
+export type FirstNameFieldProps = {
+  user: Nullable<User>;
+};
+
+export const FirstNameField = (props: FirstNameFieldProps) => {
+  const { user } = props;
   const { firstName, setFieldValue, firstNameError } =
     useConfigureProfileFormStore(selector, shallow);
 
@@ -24,7 +31,7 @@ export const FirstNameField = () => {
         additionalMessageOnLabel="(optional)"
         key="firstName"
         required={true}
-        value={firstName}
+        value={firstName ? firstName : user?.first_name || null}
         error={firstNameError}
         onChange={(event: ChangeEvent<HTMLInputElement>) =>
           setFieldValue("firstName", event.target.value.trim())

--- a/packages/toolkit/src/view/mgmt/ConfigureProfileForm/LastNameField.tsx
+++ b/packages/toolkit/src/view/mgmt/ConfigureProfileForm/LastNameField.tsx
@@ -1,10 +1,12 @@
 import { ChangeEvent } from "react";
-import {
-  useConfigureProfileFormStore,
-  type ConfigureProfileFormStore,
-} from "../../../lib";
 import { BasicTextField } from "@instill-ai/design-system";
 import { shallow } from "zustand/shallow";
+import {
+  useConfigureProfileFormStore,
+  type Nullable,
+  type User,
+  type ConfigureProfileFormStore,
+} from "../../../lib";
 
 const selector = (state: ConfigureProfileFormStore) => ({
   lastName: state.fields.lastName,
@@ -12,7 +14,12 @@ const selector = (state: ConfigureProfileFormStore) => ({
   lastNameError: state.errors.lastName,
 });
 
-export const LastNameField = () => {
+export type LastNameFieldProps = {
+  user: Nullable<User>;
+};
+
+export const LastNameField = (props: LastNameFieldProps) => {
+  const { user } = props;
   const { lastName, setFieldValue, lastNameError } =
     useConfigureProfileFormStore(selector, shallow);
 
@@ -24,7 +31,7 @@ export const LastNameField = () => {
         key="lastName"
         additionalMessageOnLabel="(optional)"
         required={true}
-        value={lastName}
+        value={lastName ? lastName : user?.last_name || null}
         error={lastNameError}
         onChange={(event: ChangeEvent<HTMLInputElement>) =>
           setFieldValue("lastName", event.target.value.trim())

--- a/packages/toolkit/src/view/mgmt/ConfigureProfileForm/NewsletterSubscriptionField.tsx
+++ b/packages/toolkit/src/view/mgmt/ConfigureProfileForm/NewsletterSubscriptionField.tsx
@@ -1,16 +1,25 @@
+import { shallow } from "zustand/shallow";
+import { BasicToggleField } from "@instill-ai/design-system";
 import {
   useConfigureProfileFormStore,
+  type Nullable,
+  type User,
   type ConfigureProfileFormStore,
 } from "../../../lib";
-import { BasicToggleField } from "@instill-ai/design-system";
-import { shallow } from "zustand/shallow";
 
 const selector = (state: ConfigureProfileFormStore) => ({
   newsletterSubscription: state.fields.newsletterSubscription,
   setFieldValue: state.setFieldValue,
 });
 
-export const NewsletterSubscriptionField = () => {
+export type NewsletterSubscriptionFieldProps = {
+  user: Nullable<User>;
+};
+
+export const NewsletterSubscriptionField = (
+  props: NewsletterSubscriptionFieldProps
+) => {
+  const { user } = props;
   const { newsletterSubscription, setFieldValue } =
     useConfigureProfileFormStore(selector, shallow);
 
@@ -19,7 +28,11 @@ export const NewsletterSubscriptionField = () => {
       <BasicToggleField
         id="newsletterSubscription"
         label="Newsletter subscription"
-        value={newsletterSubscription}
+        value={
+          newsletterSubscription
+            ? newsletterSubscription
+            : user?.newsletter_subscription || false
+        }
         required={true}
         description="Receive the latest news from Instill AI for open source updates, community highlights, blog posts, useful tutorials and more! You can unsubscribe any time."
         onChange={(event) =>

--- a/packages/toolkit/src/view/mgmt/ConfigureProfileForm/OrgNameField.tsx
+++ b/packages/toolkit/src/view/mgmt/ConfigureProfileForm/OrgNameField.tsx
@@ -1,6 +1,8 @@
 import { ChangeEvent } from "react";
 import {
   useConfigureProfileFormStore,
+  type Nullable,
+  type User,
   type ConfigureProfileFormStore,
 } from "../../../lib";
 import { BasicTextField } from "@instill-ai/design-system";
@@ -12,7 +14,12 @@ const selector = (state: ConfigureProfileFormStore) => ({
   orgNameError: state.errors.orgName,
 });
 
-export const OrgNameField = () => {
+export type OrgNameFieldProps = {
+  user: Nullable<User>;
+};
+
+export const OrgNameField = (props: OrgNameFieldProps) => {
+  const { user } = props;
   const { orgName, setFieldValue, orgNameError } = useConfigureProfileFormStore(
     selector,
     shallow
@@ -26,7 +33,7 @@ export const OrgNameField = () => {
         additionalMessageOnLabel="Your company name"
         key="orgName"
         required={true}
-        value={orgName}
+        value={orgName ? orgName : user?.org_name || null}
         error={orgNameError}
         onChange={(event: ChangeEvent<HTMLInputElement>) =>
           setFieldValue("orgName", event.target.value.trim())

--- a/packages/toolkit/src/view/mgmt/ConfigureProfileForm/RoleField.tsx
+++ b/packages/toolkit/src/view/mgmt/ConfigureProfileForm/RoleField.tsx
@@ -1,16 +1,19 @@
 import { useMemo } from "react";
 import {
-  useConfigureProfileFormStore,
-  type ConfigureProfileFormStore,
-} from "../../../lib";
-import {
   BasicSingleSelect,
   SingleSelectOption,
 } from "@instill-ai/design-system";
 import { shallow } from "zustand/shallow";
+import {
+  useConfigureProfileFormStore,
+  type Nullable,
+  type User,
+  type ConfigureProfileFormStore,
+} from "../../../lib";
 
 export type RoleFieldProps = {
   roles: SingleSelectOption[];
+  user: Nullable<User>;
 };
 
 const selector = (state: ConfigureProfileFormStore) => ({
@@ -19,7 +22,8 @@ const selector = (state: ConfigureProfileFormStore) => ({
   roleError: state.errors.role,
 });
 
-export const RoleField = ({ roles }: RoleFieldProps) => {
+export const RoleField = (props: RoleFieldProps) => {
+  const { roles, user } = props;
   const { role, setFieldValue, roleError } = useConfigureProfileFormStore(
     selector,
     shallow
@@ -28,6 +32,10 @@ export const RoleField = ({ roles }: RoleFieldProps) => {
   const selectedRoleOption = useMemo(() => {
     return roles.find((e) => e.value === role) || null;
   }, [roles, role]);
+
+  const currentRoleOption = useMemo(() => {
+    return roles.find((e) => e.value === user?.role) || null;
+  }, [roles, user]);
 
   return (
     <div className="w-[287px]">
@@ -38,7 +46,7 @@ export const RoleField = ({ roles }: RoleFieldProps) => {
         key="role"
         required={true}
         options={roles}
-        value={selectedRoleOption}
+        value={selectedRoleOption ? selectedRoleOption : currentRoleOption}
         error={roleError}
         onChange={(option) =>
           setFieldValue("role", option ? option.value.toString() : null)

--- a/packages/toolkit/src/view/mgmt/ConfigureProfileForm/UserNameField.tsx
+++ b/packages/toolkit/src/view/mgmt/ConfigureProfileForm/UserNameField.tsx
@@ -1,11 +1,13 @@
 import { ChangeEvent } from "react";
+import { BasicTextField } from "@instill-ai/design-system";
+import { shallow } from "zustand/shallow";
 import {
   useConfigureProfileFormStore,
   validateResourceId,
+  type Nullable,
+  type User,
   type ConfigureProfileFormStore,
 } from "../../../lib";
-import { BasicTextField } from "@instill-ai/design-system";
-import { shallow } from "zustand/shallow";
 
 const selector = (state: ConfigureProfileFormStore) => ({
   userName: state.fields.userName,
@@ -14,7 +16,12 @@ const selector = (state: ConfigureProfileFormStore) => ({
   setFieldError: state.setFieldError,
 });
 
-export const UserNameField = () => {
+export type UserNameFieldProps = {
+  user: Nullable<User>;
+};
+
+export const UserNameField = (props: UserNameFieldProps) => {
+  const { user } = props;
   const { userName, userNameError, setFieldValue, setFieldError } =
     useConfigureProfileFormStore(selector, shallow);
 
@@ -26,7 +33,7 @@ export const UserNameField = () => {
         key="userName"
         additionalMessageOnLabel="This will be your unique identifier"
         required={true}
-        value={userName}
+        value={userName ? userName : user?.name || null}
         error={userNameError}
         onChange={(event: ChangeEvent<HTMLInputElement>) => {
           const value = event.target.value.trim();

--- a/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineForm.tsx
+++ b/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineForm.tsx
@@ -109,7 +109,7 @@ export const ConfigurePipelineForm = ({
     <>
       <FormRoot marginBottom={marginBottom} formLess={false} width={width}>
         <div className="flex flex-col gap-y-10">
-          <PipelineDescriptionField />
+          <PipelineDescriptionField pipeline={pipeline} />
           <ConfigurePipelineFormControl
             pipeline={pipeline}
             setMessageBoxState={setMessageBoxState}

--- a/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineFormControl.tsx
+++ b/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineFormControl.tsx
@@ -31,12 +31,10 @@ export type ConfigurePipelineFormControlProps = {
   accessToken: Nullable<string>;
 };
 
-export const ConfigurePipelineFormControl = ({
-  pipeline,
-  setMessageBoxState,
-  onConfigure,
-  accessToken,
-}: ConfigurePipelineFormControlProps) => {
+export const ConfigurePipelineFormControl = (
+  props: ConfigurePipelineFormControlProps
+) => {
+  const { pipeline, setMessageBoxState, onConfigure, accessToken } = props;
   const enable = useCreateUpdateDeleteResourceGuard();
   const {
     canEdit,

--- a/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/PipelineDescriptionField.tsx
+++ b/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/PipelineDescriptionField.tsx
@@ -3,6 +3,8 @@ import { shallow } from "zustand/shallow";
 import { BasicTextArea } from "@instill-ai/design-system";
 import {
   useConfigurePipelineFormStore,
+  type Nullable,
+  type Pipeline,
   type ConfigurePipelineFormStore,
 } from "../../../lib";
 
@@ -13,7 +15,14 @@ const selector = (state: ConfigurePipelineFormStore) => ({
   setFieldValue: state.setFieldValue,
 });
 
-export const PipelineDescriptionField = () => {
+export type PipelineDescriptionFieldProps = {
+  pipeline: Nullable<Pipeline>;
+};
+
+export const PipelineDescriptionField = (
+  props: PipelineDescriptionFieldProps
+) => {
+  const { pipeline } = props;
   const {
     pipelineDescription,
     pipelineDescriptionError,
@@ -29,8 +38,12 @@ export const PipelineDescriptionField = () => {
       description="Fill with a short description."
       required={false}
       disabled={canEdit ? false : true}
-      error={pipelineDescription}
-      value={pipelineDescriptionError}
+      error={pipelineDescriptionError}
+      value={
+        pipelineDescription
+          ? pipelineDescription
+          : pipeline?.description || null
+      }
       onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
         setFieldValue("pipelineDescription", event.target.value);
       }}


### PR DESCRIPTION
Because

- digest user object in the configure profile form to make the form display current user info

This commit

- digest user object in the configure profile form