### PR TITLE
fix: fix delete resource modal not close right after confirmation

### DIFF
--- a/packages/toolkit/src/components/DeleteResourceModal.tsx
+++ b/packages/toolkit/src/components/DeleteResourceModal.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useCallback, useMemo, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { shallow } from "zustand/shallow";
 import {
   BasicTextField,
@@ -105,6 +105,10 @@ export const DeleteResourceModal = ({
 
   const [confirmationCode, setConfirmationCode] =
     useState<Nullable<string>>(null);
+
+  useEffect(() => {
+    setConfirmationCode(null);
+  }, [open]);
 
   const handleCodeChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/toolkit/src/view/destination/ConfigureDestinationForm.tsx
+++ b/packages/toolkit/src/view/destination/ConfigureDestinationForm.tsx
@@ -25,14 +25,14 @@ import {
   useCreateUpdateDeleteResourceGuard,
   useModalStore,
   useCreateResourceFormStore,
+  getInstillApiErrorMessage,
   type AirbyteFieldErrors,
   type AirbyteFieldValues,
   type DestinationWithDefinition,
   type UpdateDestinationPayload,
   type Nullable,
   type CreateResourceFormStore,
-  ModalStore,
-  getInstillApiErrorMessage,
+  type ModalStore,
 } from "../../lib";
 
 import { AirbyteDestinationFields } from "../airbyte";
@@ -349,6 +349,8 @@ export const ConfigureDestinationForm = ({
       message: "Deleting...",
     }));
 
+    closeModal();
+
     deleteDestination.mutate(
       { destinationName: destination.name, accessToken },
       {
@@ -388,7 +390,6 @@ export const ConfigureDestinationForm = ({
         },
       }
     );
-    closeModal();
   }, [
     amplitudeIsInit,
     deleteDestination,

--- a/packages/toolkit/src/view/model/ConfigureModelForm.tsx
+++ b/packages/toolkit/src/view/model/ConfigureModelForm.tsx
@@ -179,6 +179,8 @@ export const ConfigureModelForm: FC<ConfigureModelFormProps> = ({
       status: "progressing",
     });
 
+    closeModal();
+
     deleteModel.mutate(
       {
         modelName: model.name,
@@ -198,8 +200,6 @@ export const ConfigureModelForm: FC<ConfigureModelFormProps> = ({
               process: "model",
             });
           }
-
-          closeModal();
 
           if (onDelete) {
             onDelete();
@@ -221,7 +221,6 @@ export const ConfigureModelForm: FC<ConfigureModelFormProps> = ({
               status: "error",
             });
           }
-          closeModal();
         },
       }
     );

--- a/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineForm.tsx
+++ b/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineForm.tsx
@@ -57,6 +57,8 @@ export const ConfigurePipelineForm = ({
       message: "Deleting...",
     });
 
+    closeModal();
+
     deletePipeline.mutate(
       { pipelineName: pipeline.name, accessToken },
       {
@@ -94,7 +96,6 @@ export const ConfigurePipelineForm = ({
         },
       }
     );
-    closeModal();
   }, [
     pipeline,
     amplitudeIsInit,

--- a/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineFormControl.tsx
+++ b/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineFormControl.tsx
@@ -11,10 +11,10 @@ import {
   useCreateUpdateDeleteResourceGuard,
   useModalStore,
   useUpdatePipeline,
+  getInstillApiErrorMessage,
   type Pipeline,
   type Nullable,
   type ConfigurePipelineFormStore,
-  getInstillApiErrorMessage,
 } from "../../../lib";
 
 const selector = (state: ConfigurePipelineFormStore) => ({

--- a/packages/toolkit/src/view/source/ConfigureSourceForm/ConfigureSourceControl.tsx
+++ b/packages/toolkit/src/view/source/ConfigureSourceForm/ConfigureSourceControl.tsx
@@ -15,7 +15,7 @@ import {
   useAmplitudeCtx,
   getInstillApiErrorMessage,
   sendAmplitudeData,
-  ModalStore,
+  type ModalStore,
   type Nullable,
   type SourceWithPipelines,
   type ConfigureSourceFormStore,
@@ -87,6 +87,8 @@ export const ConfigureSourceControl = ({
       message: "Deleting...",
     }));
 
+    closeModal();
+
     deleteSource.mutate(
       {
         sourceName: source.name,
@@ -128,7 +130,6 @@ export const ConfigureSourceControl = ({
         },
       }
     );
-    closeModal();
   }, [
     source,
     amplitudeIsInit,


### PR DESCRIPTION
Because

- delete resource modal didn't close right after user confirmation

This commit

- fix delete resource modal not close right after confirmation
