### PR TITLE
feat: expose disableDelete and disableConfigure props

### DIFF
--- a/packages/toolkit/src/view/destination/ConfigureDestinationForm.tsx
+++ b/packages/toolkit/src/view/destination/ConfigureDestinationForm.tsx
@@ -22,7 +22,6 @@ import {
   useUpdateDestination,
   useAmplitudeCtx,
   sendAmplitudeData,
-  useCreateUpdateDeleteResourceGuard,
   useModalStore,
   useCreateResourceFormStore,
   getInstillApiErrorMessage,
@@ -42,8 +41,10 @@ export type ConfigureDestinationFormProps = {
   destination: DestinationWithDefinition;
   width: Nullable<string>;
   onConfigure: Nullable<() => void>;
+  disableConfigure: boolean;
   initStoreOnConfigure: boolean;
   onDelete: Nullable<() => void>;
+  disableDelete: boolean;
   accessToken: Nullable<string>;
 };
 
@@ -64,6 +65,8 @@ export const ConfigureDestinationForm = ({
   initStoreOnConfigure,
   width,
   accessToken,
+  disableConfigure,
+  disableDelete,
 }: ConfigureDestinationFormProps) => {
   const { amplitudeIsInit } = useAmplitudeCtx();
 
@@ -337,7 +340,6 @@ export const ConfigureDestinationForm = ({
   // # Handle delete destination                                              #
   // ##########################################################################
 
-  const enableGuard = useCreateUpdateDeleteResourceGuard();
   const deleteDestination = useDeleteDestination();
   const handleDeleteDestination = useCallback(() => {
     if (!destination) return;
@@ -445,7 +447,7 @@ export const ConfigureDestinationForm = ({
         </div>
         <div className="mb-10 flex flex-row">
           <OutlineButton
-            disabled={enableGuard}
+            disabled={disableDelete ? true : false}
             onClickHandler={() => openModal()}
             position="mr-auto my-auto"
             type="button"
@@ -457,7 +459,9 @@ export const ConfigureDestinationForm = ({
           <SolidButton
             type="button"
             color="primary"
-            disabled={isSyncDestination}
+            disabled={
+              disableConfigure ? true : isSyncDestination ? true : false
+            }
             position="ml-auto my-auto"
             onClickHandler={() => handleSubmit()}
           >

--- a/packages/toolkit/src/view/model/ConfigureModelForm.tsx
+++ b/packages/toolkit/src/view/model/ConfigureModelForm.tsx
@@ -14,7 +14,6 @@ import {
   useUpdateModel,
   sendAmplitudeData,
   useAmplitudeCtx,
-  useCreateUpdateDeleteResourceGuard,
   useConfigureModelFormStore,
   useModalStore,
   getInstillApiErrorMessage,
@@ -31,7 +30,9 @@ export type ConfigureModelFormProps = {
   model: Nullable<Model>;
   marginBottom: Nullable<string>;
   onConfigure: Nullable<() => void>;
+  disableConfigure: boolean;
   onDelete: Nullable<() => void>;
+  disableDelete: boolean;
 };
 
 const formSelector = (state: ConfigureModelFormStore) => ({
@@ -50,7 +51,9 @@ export const ConfigureModelForm: FC<ConfigureModelFormProps> = ({
   model,
   marginBottom,
   onConfigure,
+  disableConfigure,
   onDelete,
+  disableDelete,
 }) => {
   const { amplitudeIsInit } = useAmplitudeCtx();
   /* -------------------------------------------------------------------------
@@ -166,9 +169,7 @@ export const ConfigureModelForm: FC<ConfigureModelFormProps> = ({
    * Handle delete model
    * -----------------------------------------------------------------------*/
 
-  const enableGuard = useCreateUpdateDeleteResourceGuard();
   const deleteModel = useDeleteModel();
-
   const handleDeleteModel = useCallback(() => {
     if (!model) return;
 
@@ -250,7 +251,7 @@ export const ConfigureModelForm: FC<ConfigureModelFormProps> = ({
         </div>
         <div className="mb-8 flex flex-row">
           <OutlineButton
-            disabled={enableGuard}
+            disabled={disableDelete ? true : false}
             onClickHandler={() => openModal()}
             position="mr-auto my-auto"
             type="button"
@@ -260,7 +261,7 @@ export const ConfigureModelForm: FC<ConfigureModelFormProps> = ({
             Delete
           </OutlineButton>
           <SolidButton
-            disabled={false}
+            disabled={disableConfigure ? true : false}
             onClickHandler={handleConfigureModel}
             position="ml-auto my-auto"
             type="button"

--- a/packages/toolkit/src/view/model/CreateModelForm.tsx
+++ b/packages/toolkit/src/view/model/CreateModelForm.tsx
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { ChangeEvent, useCallback, useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { shallow } from "zustand/shallow";
@@ -36,7 +37,6 @@ import {
   type Nullable,
   type CreateResourceFormStore,
 } from "../../lib";
-import axios from "axios";
 
 export type CreateModelFormValue = {
   id: Nullable<string>;

--- a/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineForm.tsx
+++ b/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineForm.tsx
@@ -25,7 +25,9 @@ export type ConfigurePipelineFormProps = {
   width: Nullable<string>;
   accessToken: Nullable<string>;
   onConfigure: Nullable<() => void>;
+  disableConfigure: boolean;
   onDelete: Nullable<() => void>;
+  disableDelete: boolean;
 };
 
 export const ConfigurePipelineForm = ({
@@ -34,7 +36,9 @@ export const ConfigurePipelineForm = ({
   pipeline,
   accessToken,
   onConfigure,
+  disableConfigure,
   onDelete,
+  disableDelete,
 }: ConfigurePipelineFormProps) => {
   const [messsageBoxState, setMessageBoxState] =
     useState<ProgressMessageBoxState>({
@@ -116,6 +120,8 @@ export const ConfigurePipelineForm = ({
             setMessageBoxState={setMessageBoxState}
             onConfigure={onConfigure}
             accessToken={accessToken}
+            disableConfigure={disableConfigure}
+            disableDelete={disableDelete}
           />
           <div className="flex">
             <BasicProgressMessageBox

--- a/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineFormControl.tsx
+++ b/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineFormControl.tsx
@@ -8,7 +8,6 @@ import {
 } from "@instill-ai/design-system";
 import {
   useConfigurePipelineFormStore,
-  useCreateUpdateDeleteResourceGuard,
   useModalStore,
   useUpdatePipeline,
   getInstillApiErrorMessage,
@@ -28,20 +27,30 @@ export type ConfigurePipelineFormControlProps = {
   pipeline: Nullable<Pipeline>;
   setMessageBoxState: Dispatch<SetStateAction<ProgressMessageBoxState>>;
   onConfigure: Nullable<() => void>;
+  disableConfigure: boolean;
   accessToken: Nullable<string>;
+  disableDelete: boolean;
 };
 
 export const ConfigurePipelineFormControl = (
   props: ConfigurePipelineFormControlProps
 ) => {
-  const { pipeline, setMessageBoxState, onConfigure, accessToken } = props;
-  const enable = useCreateUpdateDeleteResourceGuard();
+  const {
+    pipeline,
+    setMessageBoxState,
+    onConfigure,
+    accessToken,
+    disableConfigure,
+    disableDelete,
+  } = props;
+
   const {
     canEdit,
     pipelineDescription,
     setFieldValue,
     initConfigurePipelineFormStore,
   } = useConfigurePipelineFormStore(selector, shallow);
+
   const openModal = useModalStore((state) => state.openModal);
   const updatePipeline = useUpdatePipeline();
 
@@ -121,7 +130,7 @@ export const ConfigurePipelineFormControl = (
   return (
     <div className="flex flex-row">
       <OutlineButton
-        disabled={enable}
+        disabled={disableDelete ? true : false}
         onClickHandler={() => openModal()}
         position="mr-auto my-auto"
         type="button"
@@ -131,7 +140,7 @@ export const ConfigurePipelineFormControl = (
         Delete
       </OutlineButton>
       <SolidButton
-        disabled={false}
+        disabled={disableConfigure ? true : false}
         onClickHandler={() => handleSubmit()}
         position="ml-auto my-auto"
         type="button"

--- a/packages/toolkit/src/view/source/ConfigureSourceForm/ConfigureSourceControl.tsx
+++ b/packages/toolkit/src/view/source/ConfigureSourceForm/ConfigureSourceControl.tsx
@@ -9,7 +9,6 @@ import {
 } from "@instill-ai/design-system";
 import {
   useConfigureSourceFormStore,
-  useCreateUpdateDeleteResourceGuard,
   useModalStore,
   useDeleteSource,
   useAmplitudeCtx,
@@ -37,15 +36,18 @@ export type ConfigureSourceControlProps = {
   source: Nullable<SourceWithPipelines>;
   onDelete: Nullable<() => void>;
   accessToken: Nullable<string>;
+  disableDelete: boolean;
+  disableConfigure: boolean;
 };
 
 export const ConfigureSourceControl = ({
   source,
   onDelete,
   accessToken,
+  disableDelete,
+  disableConfigure,
 }: ConfigureSourceControlProps) => {
   const { amplitudeIsInit } = useAmplitudeCtx();
-  const enableGuard = useCreateUpdateDeleteResourceGuard();
   const { canEdit, setFieldValue } = useConfigureSourceFormStore(
     selector,
     shallow
@@ -147,7 +149,7 @@ export const ConfigureSourceControl = ({
     <div className="flex flex-col">
       <div className="mb-10 flex flex-row">
         <OutlineButton
-          disabled={enableGuard}
+          disabled={disableDelete ? true : false}
           onClickHandler={() => openModal()}
           position="mr-auto my-auto"
           type="button"
@@ -158,7 +160,7 @@ export const ConfigureSourceControl = ({
         </OutlineButton>
         <SolidButton
           type="submit"
-          disabled={true}
+          disabled={disableConfigure ? true : false}
           position="ml-auto my-auto"
           color="primary"
           onClickHandler={handleSubmit}

--- a/packages/toolkit/src/view/source/ConfigureSourceForm/ConfigureSourceForm.tsx
+++ b/packages/toolkit/src/view/source/ConfigureSourceForm/ConfigureSourceForm.tsx
@@ -6,6 +6,8 @@ import { SourceDefinitionField } from "./SourceDefinitionField";
 export type ConfigureSourceFormProps = {
   source: Nullable<SourceWithPipelines>;
   onDelete: Nullable<() => void>;
+  disableDelete: boolean;
+  disableConfigure: boolean;
   marginBottom: Nullable<string>;
   width: Nullable<string>;
   accessToken: Nullable<string>;
@@ -14,6 +16,8 @@ export type ConfigureSourceFormProps = {
 export const ConfigureSourceForm = ({
   source,
   onDelete,
+  disableDelete,
+  disableConfigure,
   marginBottom,
   width,
   accessToken,
@@ -26,6 +30,8 @@ export const ConfigureSourceForm = ({
           source={source}
           onDelete={onDelete}
           accessToken={accessToken}
+          disableDelete={disableDelete}
+          disableConfigure={disableConfigure}
         />
       </div>
     </FormRoot>


### PR DESCRIPTION
Because

- let the consumers choose whether they want to disable user action or not

This commit

- expose disableDelete and disableConfigure props
