### PR TITLE
fix: treat env config as boolean and int instead of string

### DIFF
--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -11,6 +11,8 @@ When using this toolkit, you need to set up below environment variables
 - NEXT_PUBLIC_API_VERSION (string)
 - NEXT_PUBLIC_DISABLE_CREATE_UPDATE_DELETE_RESOURCE (boolean)
 - NEXT_PUBLIC_LIST_PAGE_SIZE (number)
+- NEXT_PUBLIC_AMPLITUDE_KEY (string)
+- NEXT_PUBLIC_API_GATEWAY_BASE_URL (string)
 
 ## About the flow of generating Airbyte connector's form
 

--- a/packages/toolkit/src/lib/hook/useCreateUpdateDeleteResourceGuard.tsx
+++ b/packages/toolkit/src/lib/hook/useCreateUpdateDeleteResourceGuard.tsx
@@ -5,11 +5,7 @@ export function useCreateUpdateDeleteResourceGuard() {
   const [enable, setEnable] = useState(false);
 
   useEffect(() => {
-    setEnable(
-      env("NEXT_PUBLIC_DISABLE_CREATE_UPDATE_DELETE_RESOURCE") === "true"
-        ? true
-        : false
-    );
+    setEnable(env("NEXT_PUBLIC_DISABLE_CREATE_UPDATE_DELETE_RESOURCE"));
   }, []);
 
   return enable;

--- a/packages/toolkit/src/lib/react-query-service/connector/destination/useCreateDestination.ts
+++ b/packages/toolkit/src/lib/react-query-service/connector/destination/useCreateDestination.ts
@@ -19,10 +19,7 @@ export const useCreateDestination = () => {
       accessToken: Nullable<string>;
       payload: CreateDestinationPayload;
     }) => {
-      if (
-        env("NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH") === "true" &&
-        !accessToken
-      ) {
+      if (env("NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH") && !accessToken) {
         throw new Error(
           "You had set NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH=true but didn't provide necessary access token"
         );

--- a/packages/toolkit/src/lib/react-query-service/connector/destination/useDeleteDestination.ts
+++ b/packages/toolkit/src/lib/react-query-service/connector/destination/useDeleteDestination.ts
@@ -16,10 +16,7 @@ export const useDeleteDestination = () => {
       accessToken: Nullable<string>;
       destinationName: string;
     }) => {
-      if (
-        env("NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH") === "true" &&
-        !accessToken
-      ) {
+      if (env("NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH") && !accessToken) {
         throw new Error(
           "You had set NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH=true but didn't provide necessary access token"
         );

--- a/packages/toolkit/src/lib/react-query-service/connector/destination/useDestination.ts
+++ b/packages/toolkit/src/lib/react-query-service/connector/destination/useDestination.ts
@@ -16,7 +16,7 @@ export const useDestination = ({
   accessToken: Nullable<string>;
   enable: boolean;
 }) => {
-  if (env("NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH") === "true" && !accessToken) {
+  if (env("NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH") && !accessToken) {
     throw new Error(
       "You had set NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH=true but didn't provide necessary access token"
     );

--- a/packages/toolkit/src/lib/react-query-service/connector/destination/useDestinationDefinitions.ts
+++ b/packages/toolkit/src/lib/react-query-service/connector/destination/useDestinationDefinitions.ts
@@ -11,7 +11,7 @@ export const useDestinationDefinitions = ({
   accessToken: Nullable<string>;
   enable: boolean;
 }) => {
-  if (env("NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH") === "true" && !accessToken) {
+  if (env("NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH") && !accessToken) {
     throw new Error(
       "You had set NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH=true but didn't provide necessary access token"
     );

--- a/packages/toolkit/src/lib/react-query-service/connector/destination/useUpdateDestination.ts
+++ b/packages/toolkit/src/lib/react-query-service/connector/destination/useUpdateDestination.ts
@@ -18,10 +18,7 @@ export const useUpdateDestination = () => {
       accessToken: Nullable<string>;
       payload: UpdateDestinationPayload;
     }) => {
-      if (
-        env("NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH") === "true" &&
-        !accessToken
-      ) {
+      if (env("NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH") && !accessToken) {
         throw new Error(
           "You had set NEXT_PUBLIC_ENABLE_INSTILL_API_AUTH=true but didn't provide necessary access token"
         );


### PR DESCRIPTION
Because

- Old env config is treating boolean and int as string

This commit

- treat env config as boolean and int instead of string
