### PR TITLE
fix: fix axios client base url

### DIFF
--- a/packages/toolkit/src/lib/vdp-sdk/helper/createInstillAxiosClient.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/helper/createInstillAxiosClient.ts
@@ -10,9 +10,10 @@ export const createInstillAxiosClient = (accessToken: Nullable<string>) => {
     : {};
 
   return axios.create({
-    baseURL: `${env("NEXT_PUBLIC_API_GATEWAY_BASE_URL")}/${env(
-      "NEXT_PUBLIC_API_VERSION"
-    )}`,
+    baseURL: `${
+      process.env.NEXT_SERVER_API_GATEWAY_BASE_URL ??
+      env("NEXT_PUBLIC_API_GATEWAY_BASE_URL")
+    }/${env("NEXT_PUBLIC_API_VERSION")}`,
     headers,
   });
 };


### PR DESCRIPTION
Because

- the axios client base url didn't use server side API base url

This commit

- fix axios client base url