### PR TITLE
fix: add disabled props into toggle button

### DIFF
--- a/packages/toolkit/src/view/model/ChangeModelStateToggle.tsx
+++ b/packages/toolkit/src/view/model/ChangeModelStateToggle.tsx
@@ -29,6 +29,7 @@ export type ChangeModelStateToggleProps = {
   >;
   marginBottom?: string;
   accessToken: Nullable<string>;
+  disabled: boolean;
 };
 
 export const ChangeModelStateToggle: FC<ChangeModelStateToggleProps> = ({
@@ -38,6 +39,7 @@ export const ChangeModelStateToggle: FC<ChangeModelStateToggleProps> = ({
   switchOff,
   marginBottom,
   accessToken,
+  disabled,
 }) => {
   const [error, setError] = useState<Nullable<string>>(null);
 
@@ -108,7 +110,7 @@ export const ChangeModelStateToggle: FC<ChangeModelStateToggleProps> = ({
             ? "STATE_LOADING"
             : modelWatchState || "STATE_UNSPECIFIED"
         }
-        disabled={modelWatchState === "STATE_UNSPECIFIED"}
+        disabled={disabled ? true : modelWatchState === "STATE_UNSPECIFIED"}
         loadingLabelText="Model is in the long running operation, please refresh this page to get the new status"
       />
     </div>

--- a/packages/toolkit/src/view/pipeline/ChangePipelineStateToggle.tsx
+++ b/packages/toolkit/src/view/pipeline/ChangePipelineStateToggle.tsx
@@ -29,6 +29,7 @@ export type ChangePipelineStateToggleProps = {
   >;
   marginBottom?: string;
   accessToken: Nullable<string>;
+  disabled: boolean;
 };
 
 export const ChangePipelineStateToggle: FC<ChangePipelineStateToggleProps> = ({
@@ -38,6 +39,7 @@ export const ChangePipelineStateToggle: FC<ChangePipelineStateToggleProps> = ({
   switchOff,
   marginBottom,
   accessToken,
+  disabled,
 }) => {
   const [error, setError] = useState<Nullable<string>>(null);
 
@@ -111,7 +113,7 @@ export const ChangePipelineStateToggle: FC<ChangePipelineStateToggleProps> = ({
             ? "STATE_LOADING"
             : pipelineWatchState || "STATE_UNSPECIFIED"
         }
-        disabled={pipelineWatchState === "STATE_UNSPECIFIED"}
+        disabled={disabled ? true : pipelineWatchState === "STATE_UNSPECIFIED"}
         loadingLabelText="Pipeline is in the long running operation, please refresh this page to get the new status"
       />
     </div>


### PR DESCRIPTION
Because

- ToggelButton of resource state should have a way to be disabled

This commit

-  add disabled props into toggle button