### PR TITLE
refactor: deprecate FC type in design-system

### DIFF
--- a/packages/toolkit/src/components/cells/ModeCell.tsx
+++ b/packages/toolkit/src/components/cells/ModeCell.tsx
@@ -1,5 +1,5 @@
 import cn from "clsx";
-import { FC, ReactElement } from "react";
+import { ReactElement } from "react";
 import { AsyncIcon, SyncIcon } from "@instill-ai/design-system";
 import { Nullable, PipelineMode } from "../../lib";
 
@@ -9,7 +9,7 @@ export type ModeCellProps = {
   padding: string;
 };
 
-export const ModeCell: FC<ModeCellProps> = ({ width, mode, padding }) => {
+export const ModeCell = ({ width, mode, padding }: ModeCellProps) => {
   let modeIcon: ReactElement;
   const iconStyle = {
     width: "w-5",

--- a/packages/toolkit/src/view/airbyte/AirbyteDestinationFields.tsx
+++ b/packages/toolkit/src/view/airbyte/AirbyteDestinationFields.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, FC, Fragment, SetStateAction } from "react";
+import { Dispatch, Fragment, SetStateAction } from "react";
 import {
   AirbyteFieldErrors,
   AirbyteFieldValues,
@@ -20,7 +20,7 @@ export type AirbyteDestinationFieldsProps = {
   setFormIsDirty: Dispatch<SetStateAction<boolean>>;
 };
 
-export const AirbyteDestinationFields: FC<AirbyteDestinationFieldsProps> = ({
+export const AirbyteDestinationFields = ({
   fieldValues,
   setFieldValues,
   fieldErrors,
@@ -30,7 +30,7 @@ export const AirbyteDestinationFields: FC<AirbyteDestinationFieldsProps> = ({
   disableAll,
   formIsDirty,
   setFormIsDirty,
-}) => {
+}: AirbyteDestinationFieldsProps) => {
   const fields = useBuildAirbyteFields(
     destinationFormTree,
     disableAll,

--- a/packages/toolkit/src/view/airbyte/OneOfConditionSection.tsx
+++ b/packages/toolkit/src/view/airbyte/OneOfConditionSection.tsx
@@ -4,7 +4,6 @@ import {
   useState,
   useEffect,
   type Dispatch,
-  type FC,
   type SetStateAction,
 } from "react";
 import {
@@ -33,7 +32,7 @@ export type OneOfConditionSectionProps = {
   setFormIsDirty: Dispatch<SetStateAction<boolean>>;
 };
 
-export const OneOfConditionSection: FC<OneOfConditionSectionProps> = ({
+export const OneOfConditionSection = ({
   formTree,
   errors,
   setValues,
@@ -42,7 +41,7 @@ export const OneOfConditionSection: FC<OneOfConditionSectionProps> = ({
   disableAll,
   formIsDirty,
   setFormIsDirty,
-}) => {
+}: OneOfConditionSectionProps) => {
   // ##########################################################################
   // # 1 - Initialize state                                                   #
   // ##########################################################################

--- a/packages/toolkit/src/view/destination/DestinationTablePlaceholder.tsx
+++ b/packages/toolkit/src/view/destination/DestinationTablePlaceholder.tsx
@@ -1,4 +1,3 @@
-import { FC } from "react";
 import {
   AwsRdsIcon,
   MongoDbIcon,
@@ -18,9 +17,10 @@ export type DestinationTablePlaceholderProps = {
   enablePlaceholderCreateButton: TablePlaceholderBaseProps["enableCreateButton"];
 };
 
-export const DestinationTablePlaceholder: FC<
-  DestinationTablePlaceholderProps
-> = ({ marginBottom, enablePlaceholderCreateButton }) => {
+export const DestinationTablePlaceholder = ({
+  marginBottom,
+  enablePlaceholderCreateButton,
+}: DestinationTablePlaceholderProps) => {
   const width = "w-[136px]";
   const height = "h-[136px]";
 

--- a/packages/toolkit/src/view/model/ChangeModelStateToggle.tsx
+++ b/packages/toolkit/src/view/model/ChangeModelStateToggle.tsx
@@ -1,7 +1,7 @@
 import cn from "clsx";
 import axios from "axios";
 import { StatefulToggleField } from "@instill-ai/design-system";
-import { FC, useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { UseMutationResult } from "@tanstack/react-query";
 
 import { Model, ModelState, Nullable, Operation } from "../../lib";
@@ -32,7 +32,7 @@ export type ChangeModelStateToggleProps = {
   disabled: boolean;
 };
 
-export const ChangeModelStateToggle: FC<ChangeModelStateToggleProps> = ({
+export const ChangeModelStateToggle = ({
   model,
   modelWatchState,
   switchOn,
@@ -40,7 +40,7 @@ export const ChangeModelStateToggle: FC<ChangeModelStateToggleProps> = ({
   marginBottom,
   accessToken,
   disabled,
-}) => {
+}: ChangeModelStateToggleProps) => {
   const [error, setError] = useState<Nullable<string>>(null);
 
   useEffect(() => {

--- a/packages/toolkit/src/view/model/ConfigureModelForm.tsx
+++ b/packages/toolkit/src/view/model/ConfigureModelForm.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import axios from "axios";
 import {
   BasicProgressMessageBox,
@@ -47,14 +47,14 @@ const modalSelector = (state: ModalStore) => ({
   closeModal: state.closeModal,
 });
 
-export const ConfigureModelForm: FC<ConfigureModelFormProps> = ({
+export const ConfigureModelForm = ({
   model,
   marginBottom,
   onConfigure,
   disableConfigure,
   onDelete,
   disableDelete,
-}) => {
+}: ConfigureModelFormProps) => {
   const { amplitudeIsInit } = useAmplitudeCtx();
   /* -------------------------------------------------------------------------
    * Initialize form state

--- a/packages/toolkit/src/view/model/ModelTablePlaceholder.tsx
+++ b/packages/toolkit/src/view/model/ModelTablePlaceholder.tsx
@@ -1,4 +1,3 @@
-import { FC } from "react";
 import {
   ImageClassificationIcon,
   InstanceSegmentationIcon,
@@ -18,10 +17,10 @@ export type ModelTablePlaceholderProps = {
   enablePlaceholderCreateButton: TablePlaceholderBaseProps["enableCreateButton"];
 };
 
-export const ModelTablePlaceholder: FC<ModelTablePlaceholderProps> = ({
+export const ModelTablePlaceholder = ({
   marginBottom,
   enablePlaceholderCreateButton,
-}) => {
+}: ModelTablePlaceholderProps) => {
   const width = "w-[136px]";
   const height = "h-[136px]";
 

--- a/packages/toolkit/src/view/pipeline/ChangePipelineStateToggle.tsx
+++ b/packages/toolkit/src/view/pipeline/ChangePipelineStateToggle.tsx
@@ -1,6 +1,6 @@
 import cn from "clsx";
 import axios from "axios";
-import { FC, useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { StatefulToggleField } from "@instill-ai/design-system";
 import { UseMutationResult } from "@tanstack/react-query";
 
@@ -32,7 +32,7 @@ export type ChangePipelineStateToggleProps = {
   disabled: boolean;
 };
 
-export const ChangePipelineStateToggle: FC<ChangePipelineStateToggleProps> = ({
+export const ChangePipelineStateToggle = ({
   pipeline,
   pipelineWatchState,
   switchOn,
@@ -40,7 +40,7 @@ export const ChangePipelineStateToggle: FC<ChangePipelineStateToggleProps> = ({
   marginBottom,
   accessToken,
   disabled,
-}) => {
+}: ChangePipelineStateToggleProps) => {
   const [error, setError] = useState<Nullable<string>>(null);
 
   useEffect(() => {

--- a/packages/toolkit/src/view/pipeline/PipelineTablePlaceholder.tsx
+++ b/packages/toolkit/src/view/pipeline/PipelineTablePlaceholder.tsx
@@ -1,6 +1,4 @@
 import cn from "clsx";
-import { FC } from "react";
-
 import {
   TablePlaceholderBase,
   type TablePlaceholderBaseProps,
@@ -11,10 +9,10 @@ export type PipelineTablePlaceholderProps = {
   enablePlaceholderCreateButton: TablePlaceholderBaseProps["enableCreateButton"];
 };
 
-export const PipelineTablePlaceholder: FC<PipelineTablePlaceholderProps> = ({
+export const PipelineTablePlaceholder = ({
   marginBottom,
   enablePlaceholderCreateButton,
-}) => {
+}: PipelineTablePlaceholderProps) => {
   const width = "w-[136px]";
   const height = "h-[136px]";
   const color = "fill-instillGrey95";

--- a/packages/toolkit/src/view/source/SourceTablePlaceholder.tsx
+++ b/packages/toolkit/src/view/source/SourceTablePlaceholder.tsx
@@ -1,4 +1,3 @@
-import { FC } from "react";
 import {
   AwsS3Icon,
   GcsIcon,
@@ -17,10 +16,10 @@ export type SourceTablePlaceholderProps = {
   enablePlaceholderCreateButton: TablePlaceholderBaseProps["enableCreateButton"];
 };
 
-export const SourceTablePlaceholder: FC<SourceTablePlaceholderProps> = ({
+export const SourceTablePlaceholder = ({
   marginBottom,
   enablePlaceholderCreateButton,
-}) => {
+}: SourceTablePlaceholderProps) => {
   const width = "w-[136px]";
   const height = "h-[136px]";
 


### PR DESCRIPTION
related to https://github.com/instill-ai/community/issues/341

Because

- Among all the codebase of frontend, we are deprecating FC type

This commit

- have only changes according to bellow example.
```
export const ModeCell: FC<ModeCellProps> = ({ width, mode, padding }) => {};
```
It is refactored to be like
```
export const ModeCell = ({ width, mode, padding }: ModeCellProps) => {};
```

further changes for these https://github.com/instill-ai/community/issues/341 will be added in next **PR**
