### PR TITLE
feat: rename updateLocalUserMutation to updateUserMutation

### DIFF
--- a/packages/toolkit/src/lib/react-query-service/mgmt/useUpdateUser.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/useUpdateUser.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Nullable } from "../../type";
-import { updateLocalUserMutation, User } from "../../vdp-sdk";
+import { updateUserMutation, User } from "../../vdp-sdk";
 
 export const useUpdateUser = () => {
   const queryClient = useQueryClient();
@@ -12,7 +12,7 @@ export const useUpdateUser = () => {
       payload: Partial<User>;
       accessToken: Nullable<string>;
     }) => {
-      const user = await updateLocalUserMutation({ payload, accessToken });
+      const user = await updateUserMutation({ payload, accessToken });
       return Promise.resolve(user);
     },
     {

--- a/packages/toolkit/src/lib/vdp-sdk/mgmt/mutations.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/mgmt/mutations.ts
@@ -6,7 +6,7 @@ export type UpdateUserResponse = {
   user: User;
 };
 
-export const updateLocalUserMutation = async ({
+export const updateUserMutation = async ({
   payload,
   accessToken,
 }: {


### PR DESCRIPTION
Because

- make function name consistent

This commit

- rename updateLocalUserMutation to updateUserMutation
