### PR TITLE
feat: remove interior query

### DIFF
--- a/apps/cortex-playground/src/pages/create-model.tsx
+++ b/apps/cortex-playground/src/pages/create-model.tsx
@@ -2,9 +2,16 @@ import { Root } from "@/components/Root";
 import {
   CreateModelForm,
   CreateModelWithPresetForm,
+  useModelDefinition,
+  useModelDefinitions,
 } from "@instill-ai/toolkit";
 
 const CreateModelPage = () => {
+  const modelDefinitions = useModelDefinitions({
+    accessToken: null,
+    enabled: true,
+  });
+
   return (
     <Root>
       <div className="w-[1200px]">
@@ -13,6 +20,9 @@ const CreateModelPage = () => {
           initStoreOnCreate={false}
           accessToken={null}
           disabledCreateModel={true}
+          modelDefinitions={
+            modelDefinitions.isSuccess ? modelDefinitions.data : null
+          }
         />
       </div>
     </Root>

--- a/packages/toolkit/src/view/destination/CreateDestinationForm.tsx
+++ b/packages/toolkit/src/view/destination/CreateDestinationForm.tsx
@@ -43,6 +43,7 @@ export type CreateDestinationFormProps = {
   onCreate: Nullable<(id: string) => void>;
   initStoreOnCreate: boolean;
   accessToken: Nullable<string>;
+  destinationDefinitions: Nullable<ConnectorDefinition[]>;
 } & Pick<FormRootProps, "width" | "marginBottom" | "formLess">;
 
 const selector = (state: CreateResourceFormStore) => ({
@@ -58,6 +59,7 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
     title,
     onCreate,
     initStoreOnCreate,
+    destinationDefinitions,
     accessToken,
     marginBottom,
     formLess,
@@ -84,16 +86,11 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
    * Get the destination definition and static state for fields
    * -----------------------------------------------------------------------*/
 
-  const destinationDefinitions = useDestinationDefinitions({
-    accessToken,
-    enabled: true,
-  });
-
   const destinationOptions = React.useMemo(() => {
-    if (!destinationDefinitions.isSuccess) return [];
+    if (!destinationDefinitions) return [];
 
     if (pipelineMode === "MODE_ASYNC") {
-      return destinationDefinitions.data
+      return destinationDefinitions
         .filter(
           (e) =>
             e.name !== "destination-connector-definitions/destination-http" &&
@@ -119,7 +116,7 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
         }));
     }
 
-    return destinationDefinitions.data.map((e) => ({
+    return destinationDefinitions.map((e) => ({
       label: e.connector_definition.title,
       value: e.name,
       startIcon: (
@@ -136,11 +133,7 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
         />
       ),
     }));
-  }, [
-    destinationDefinitions.isSuccess,
-    destinationDefinitions.data,
-    pipelineMode,
-  ]);
+  }, [destinationDefinitions, pipelineMode]);
 
   const [selectedDestinationDefinition, setSelectedDestinationDefinition] =
     React.useState<Nullable<ConnectorDefinition>>(null);
@@ -516,8 +509,8 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
             setFieldErrors(null);
             setSelectedDestinationOption(option);
             setSelectedDestinationDefinition(
-              destinationDefinitions.data
-                ? destinationDefinitions.data.find(
+              destinationDefinitions
+                ? destinationDefinitions.find(
                     (e) => e.name === option?.value
                   ) ?? null
                 : null

--- a/packages/toolkit/src/view/model/CreateModelForm.tsx
+++ b/packages/toolkit/src/view/model/CreateModelForm.tsx
@@ -21,7 +21,6 @@ import {
   useCreateGithubModel,
   useCreateHuggingFaceModel,
   useCreateLocalModel,
-  useModelDefinitions,
   getModelQuery,
   validateResourceId,
   useAmplitudeCtx,
@@ -37,11 +36,13 @@ import {
   type Model,
   type Nullable,
   type CreateResourceFormStore,
+  ModelDefinition,
 } from "../../lib";
 import { checkUntilOperationIsDoen } from "../../lib/vdp-sdk/operation";
 
 export type CreateModelFormProps = {
   accessToken: Nullable<string>;
+  modelDefinitions: Nullable<ModelDefinition[]>;
   initStoreOnCreate: boolean;
   onCreate: Nullable<() => void>;
   disabledCreateModel?: boolean;
@@ -78,6 +79,7 @@ const selector = (state: CreateResourceFormStore) => ({
 export const CreateModelForm = (props: CreateModelFormProps) => {
   const {
     accessToken,
+    modelDefinitions,
     marginBottom,
     initStoreOnCreate,
     onCreate,
@@ -122,15 +124,10 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
    * Initialize the model definition
    * -----------------------------------------------------------------------*/
 
-  const modelDefinitions = useModelDefinitions({
-    accessToken,
-    enabled: true,
-  });
-
   const modelDefinitionOptions = React.useMemo(() => {
-    if (!modelDefinitions.isSuccess) return [];
+    if (!modelDefinitions) return [];
 
-    return modelDefinitions.data.map((e) => {
+    return modelDefinitions.map((e) => {
       const { getIcon } = getModelDefinitionToolkit(e.name);
       return {
         label: e.title,
@@ -143,7 +140,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
         }),
       };
     });
-  }, [modelDefinitions.isSuccess, modelDefinitions.data]);
+  }, [modelDefinitions]);
 
   const [selectedModelDefinitionOption, setSelectedModelDefinitionOption] =
     React.useState<Nullable<SingleSelectOption>>(null);
@@ -631,9 +628,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
                   numbers, and hyphen, with the first character a letter, 
                   the last a letter or a number, and a 63 character maximum."
           required={true}
-          disabled={
-            modelDefinitions.isSuccess ? (modelCreated ? true : false) : false
-          }
+          disabled={modelDefinitions ? (modelCreated ? true : false) : false}
           value={modelId}
           error={modelIdError}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
@@ -663,9 +658,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
           key="description"
           description="Fill with a short description."
           required={false}
-          disabled={
-            modelDefinitions.isSuccess ? (modelCreated ? true : false) : false
-          }
+          disabled={modelDefinitions ? (modelCreated ? true : false) : false}
           value={modelDescription}
           error={modelDescriptionError}
           enableCounter={true}
@@ -685,9 +678,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
             setFieldValue("model.new.definition", option?.value);
             setSelectedModelDefinitionOption(option);
           }}
-          disabled={
-            modelDefinitions.isSuccess ? (modelCreated ? true : false) : false
-          }
+          disabled={modelDefinitions ? (modelCreated ? true : false) : false}
           required={true}
           description={`<a href="${getModelSetupGuide(
             modelDefinition || ""

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/CreatePipelineForm.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/CreatePipelineForm.tsx
@@ -3,9 +3,18 @@ import * as React from "react";
 import { Nullable, useCreateResourceFormStore } from "../../../lib";
 import { CreatePipelineProgress } from "./CreatePipelineProgress";
 import { SetPipelineDetailsStep } from "./SetPipelineDetailsStep";
-import { SetPipelineDestinationStep } from "./SetPipelineDestinationStep";
-import { SetPipelineModelStep } from "./SetPipelineModelStep";
-import { SetPipelineModeStep } from "./SetPipelineModeStep";
+import {
+  SetPipelineDestinationStep,
+  SetPipelineDestinationStepProps,
+} from "./SetPipelineDestinationStep";
+import {
+  SetPipelineModelStep,
+  SetPipelineModelStepProps,
+} from "./SetPipelineModelStep";
+import {
+  SetPipelineModeStep,
+  SetPipelineModeStepProps,
+} from "./SetPipelineModeStep";
 
 //  Currently, we make number 0 & 1 stay at the first step
 //  0: Choose pipeline mode
@@ -20,10 +29,25 @@ export type CreatePipelineFormProps = {
   accessToken: Nullable<string>;
   syncModelOnly: boolean;
   withModelPreset: boolean;
-};
+} & Pick<SetPipelineModeStepProps, "sources"> &
+  Pick<SetPipelineModelStepProps, "models" | "modelDefinitions"> &
+  Pick<
+    SetPipelineDestinationStepProps,
+    "destinationDefinitions" | "destinations"
+  >;
 
 export const CreatePipelineForm = (props: CreatePipelineFormProps) => {
-  const { onCreate, accessToken, syncModelOnly, withModelPreset } = props;
+  const {
+    onCreate,
+    accessToken,
+    syncModelOnly,
+    withModelPreset,
+    sources,
+    models,
+    modelDefinitions,
+    destinations,
+    destinationDefinitions,
+  } = props;
   const pipelineFormStep = useCreateResourceFormStore(
     (state) => state.pipelineFormStep
   );
@@ -36,6 +60,7 @@ export const CreatePipelineForm = (props: CreatePipelineFormProps) => {
           <SetPipelineModeStep
             syncModelOnly={syncModelOnly}
             accessToken={accessToken}
+            sources={sources}
           />
         );
       case 2:
@@ -43,10 +68,18 @@ export const CreatePipelineForm = (props: CreatePipelineFormProps) => {
           <SetPipelineModelStep
             withModelPreset={withModelPreset}
             accessToken={accessToken}
+            models={models}
+            modelDefinitions={modelDefinitions}
           />
         );
       case 3:
-        return <SetPipelineDestinationStep accessToken={accessToken} />;
+        return (
+          <SetPipelineDestinationStep
+            accessToken={accessToken}
+            destinations={destinations}
+            destinationDefinitions={destinationDefinitions}
+          />
+        );
       case 4:
         return (
           <SetPipelineDetailsStep

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineDestinationStep/SelectExistingDestinationFlow.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineDestinationStep/SelectExistingDestinationFlow.tsx
@@ -8,12 +8,12 @@ import {
   SolidButton,
 } from "@instill-ai/design-system";
 import {
-  useDestinations,
   useAmplitudeCtx,
   sendAmplitudeData,
   useCreateResourceFormStore,
   type CreateResourceFormStore,
   type Nullable,
+  type DestinationWithDefinition,
 } from "../../../../lib";
 
 const selector = (state: CreateResourceFormStore) => ({
@@ -24,14 +24,14 @@ const selector = (state: CreateResourceFormStore) => ({
 });
 
 export type SelectExistingDestinationFlowProps = {
-  accessToken: Nullable<string>;
   onSelect: () => void;
+  destinations: Nullable<DestinationWithDefinition[]>;
 };
 
 export const SelectExistingDestinationFlow = (
   props: SelectExistingDestinationFlowProps
 ) => {
-  const { accessToken, onSelect } = props;
+  const { onSelect, destinations } = props;
   const { amplitudeIsInit } = useAmplitudeCtx();
 
   /* -------------------------------------------------------------------------
@@ -52,14 +52,13 @@ export const SelectExistingDestinationFlow = (
   const [destinationOptions, setDestinationOptions] = React.useState<
     SingleSelectOption[] | null
   >(null);
-  const destinations = useDestinations({ accessToken, enabled: true });
 
   React.useEffect(() => {
-    if (!destinations.isSuccess || !destinations.data) return;
+    if (!destinations) return;
 
     if (pipelineMode === "MODE_ASYNC") {
       setDestinationOptions(
-        destinations.data
+        destinations
           .filter(
             (e) =>
               e.name !== "destination-connectors/destination-http" &&
@@ -89,7 +88,7 @@ export const SelectExistingDestinationFlow = (
       );
     } else {
       setDestinationOptions(
-        destinations.data.map((e) => {
+        destinations.map((e) => {
           return {
             label: e.id,
             value: e.id,
@@ -97,7 +96,7 @@ export const SelectExistingDestinationFlow = (
         })
       );
     }
-  }, [destinations.isSuccess, destinations.data, pipelineMode]);
+  }, [destinations, pipelineMode]);
 
   const [selectedDestinationOption, setSelectedDestinationOption] =
     React.useState<Nullable<SingleSelectOption>>(null);
@@ -115,7 +114,7 @@ export const SelectExistingDestinationFlow = (
   }, [existingDestinationId]);
 
   const handleUseExistingDestination = () => {
-    if (!existingDestinationId || !destinations.isSuccess) return;
+    if (!existingDestinationId || !destinations) return;
 
     setFieldValue(
       "destination.existing.definition",

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineDestinationStep/SetPipelineDestinationStep.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineDestinationStep/SetPipelineDestinationStep.tsx
@@ -9,18 +9,24 @@ import {
 } from "@instill-ai/design-system";
 import {
   useCreateDestination,
-  useDestinations,
   useAmplitudeCtx,
   sendAmplitudeData,
   useCreateResourceFormStore,
   type CreateDestinationPayload,
   type CreateResourceFormStore,
   type Nullable,
+  type DestinationWithDefinition,
 } from "../../../../lib";
 
 import { FormVerticalDivider } from "../FormVerticalDivider";
-import { SelectExistingDestinationFlow } from "./SelectExistingDestinationFlow";
-import { CreateDestinationForm } from "../../../destination";
+import {
+  SelectExistingDestinationFlow,
+  SelectExistingDestinationFlowProps,
+} from "./SelectExistingDestinationFlow";
+import {
+  CreateDestinationForm,
+  CreateDestinationFormProps,
+} from "../../../destination";
 
 const selector = (state: CreateResourceFormStore) => ({
   pipelineMode: state.fields.pipeline.mode,
@@ -35,12 +41,13 @@ const selector = (state: CreateResourceFormStore) => ({
 
 export type SetPipelineDestinationStepProps = {
   accessToken: Nullable<string>;
-};
+} & Pick<SelectExistingDestinationFlowProps, "destinations"> &
+  Pick<CreateDestinationFormProps, "destinationDefinitions">;
 
 export const SetPipelineDestinationStep = (
   props: SetPipelineDestinationStepProps
 ) => {
-  const { accessToken } = props;
+  const { accessToken, destinations, destinationDefinitions } = props;
   const { amplitudeIsInit } = useAmplitudeCtx();
 
   /* -------------------------------------------------------------------------
@@ -118,15 +125,14 @@ export const SetPipelineDestinationStep = (
    * -----------------------------------------------------------------------*/
 
   const createDestination = useCreateDestination();
-  const destinations = useDestinations({ accessToken, enabled: true });
 
   const handleGoNext = () => {
-    if (!destinations.isSuccess || !selectedSyncDestinationOption) {
+    if (!destinations || !selectedSyncDestinationOption) {
       return;
     }
 
     if (pipelineMode === "MODE_SYNC") {
-      const destinationIndex = destinations.data.findIndex(
+      const destinationIndex = destinations.findIndex(
         (e) => e.id === selectedSyncDestinationOption.value
       );
 
@@ -226,7 +232,7 @@ export const SetPipelineDestinationStep = (
               onSelect={() => {
                 increasePipelineFormStep();
               }}
-              accessToken={accessToken}
+              destinations={destinations}
             />
           </div>
           <div className="flex">
@@ -247,6 +253,7 @@ export const SetPipelineDestinationStep = (
               formLess={true}
               initStoreOnCreate={false}
               accessToken={accessToken}
+              destinationDefinitions={destinationDefinitions}
             />
           </div>
         </div>

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModeStep.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModeStep.tsx
@@ -8,6 +8,7 @@ import {
   type CreateResourceFormStore,
   type CreateSourcePayload,
   type Nullable,
+  SourceWithDefinition,
 } from "../../../lib";
 import {
   AsyncIcon,
@@ -32,10 +33,11 @@ const selector = (state: CreateResourceFormStore) => ({
 export type SetPipelineModeStepProps = {
   accessToken: Nullable<string>;
   syncModelOnly: boolean;
+  sources: Nullable<SourceWithDefinition[]>;
 };
 
 export const SetPipelineModeStep = (props: SetPipelineModeStepProps) => {
-  const { accessToken, syncModelOnly } = props;
+  const { accessToken, syncModelOnly, sources } = props;
   const { amplitudeIsInit } = useAmplitudeCtx();
 
   /* -------------------------------------------------------------------------
@@ -137,7 +139,6 @@ export const SetPipelineModeStep = (props: SetPipelineModeStepProps) => {
    * -----------------------------------------------------------------------*/
 
   const createSource = useCreateSource();
-  const sources = useSources({ accessToken, enabled: true });
 
   const canGoNext = React.useMemo(() => {
     if (!pipelineMode) return false;
@@ -149,9 +150,9 @@ export const SetPipelineModeStep = (props: SetPipelineModeStepProps) => {
   }, [pipelineMode, selectedSyncSourceOption]);
 
   const handleGoNext = () => {
-    if (!sources.isSuccess || !selectedSyncSourceOption?.value) return;
+    if (!sources || !selectedSyncSourceOption?.value) return;
 
-    const sourceIndex = sources.data.findIndex(
+    const sourceIndex = sources.findIndex(
       (e) => e.id === selectedSyncSourceOption.value
     );
 

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModelStep/SelectExistingModelFlow.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModelStep/SelectExistingModelFlow.tsx
@@ -12,6 +12,7 @@ import {
   useCreateResourceFormStore,
   type CreateResourceFormStore,
   type Nullable,
+  Model,
 } from "../../../../lib";
 
 const selector = (state: CreateResourceFormStore) => ({
@@ -22,12 +23,13 @@ const selector = (state: CreateResourceFormStore) => ({
 export type SelectExistingModelFlowProps = {
   accessToken: Nullable<string>;
   onSelect: () => void;
+  models: Nullable<Model[]>;
 };
 
 export const SelectExistingModelFlow = (
   props: SelectExistingModelFlowProps
 ) => {
-  const { accessToken, onSelect } = props;
+  const { accessToken, onSelect, models } = props;
   const { amplitudeIsInit } = useAmplitudeCtx();
 
   /* -------------------------------------------------------------------------
@@ -48,20 +50,15 @@ export const SelectExistingModelFlow = (
   const [selectedModelOption, setSelectedModelOption] =
     React.useState<Nullable<SingleSelectOption>>(null);
 
-  const models = useModels({
-    enabled: true,
-    accessToken,
-  });
-
   React.useEffect(() => {
-    if (!models.isSuccess || !models.data) return;
+    if (!models) return;
 
-    const onlineModels = models.data.filter((e) => e.state === "STATE_ONLINE");
+    const onlineModels = models.filter((e) => e.state === "STATE_ONLINE");
 
     setModelOptions(
       onlineModels.map((e) => ({ label: e.name, value: e.name }))
     );
-  }, [models.isSuccess, models.data]);
+  }, [models]);
 
   /* -------------------------------------------------------------------------
    * Use existing model
@@ -76,11 +73,11 @@ export const SelectExistingModelFlow = (
   }, [modelType]);
 
   const handleUseModel = React.useCallback(() => {
-    if (!models.isSuccess || !models.data) {
+    if (!models) {
       return;
     }
 
-    const targetModel = models.data.find(
+    const targetModel = models.find(
       (e) => e.name === (selectedModelOption?.value as string)
     );
 
@@ -98,14 +95,7 @@ export const SelectExistingModelFlow = (
         process: "pipeline",
       });
     }
-  }, [
-    models.isSuccess,
-    models.data,
-    amplitudeIsInit,
-    selectedModelOption?.value,
-    setFieldValue,
-    onSelect,
-  ]);
+  }, [amplitudeIsInit, selectedModelOption?.value, setFieldValue, onSelect]);
 
   /* -------------------------------------------------------------------------
    * Render

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModelStep/SetPipelineModelStep.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModelStep/SetPipelineModelStep.tsx
@@ -1,15 +1,23 @@
 import { FormVerticalDivider } from "../FormVerticalDivider";
-import { SelectExistingModelFlow } from "./SelectExistingModelFlow";
-import { CreateModelForm, CreateModelWithPresetForm } from "../../../model";
+import {
+  SelectExistingModelFlow,
+  SelectExistingModelFlowProps,
+} from "./SelectExistingModelFlow";
+import {
+  CreateModelForm,
+  CreateModelFormProps,
+  CreateModelWithPresetForm,
+} from "../../../model";
 import { useCreateResourceFormStore, type Nullable } from "../../../../lib";
 
 export type SetPipelineModelStepProps = {
   accessToken: Nullable<string>;
   withModelPreset: boolean;
-};
+} & Pick<SelectExistingModelFlowProps, "models"> &
+  Pick<CreateModelFormProps, "modelDefinitions">;
 
 export const SetPipelineModelStep = (props: SetPipelineModelStepProps) => {
-  const { accessToken, withModelPreset } = props;
+  const { accessToken, withModelPreset, models, modelDefinitions } = props;
   const increasePipelineFormStep = useCreateResourceFormStore(
     (state) => state.increasePipelineFormStep
   );
@@ -22,6 +30,7 @@ export const SetPipelineModelStep = (props: SetPipelineModelStepProps) => {
             increasePipelineFormStep();
           }}
           accessToken={accessToken}
+          models={models}
         />
       </div>
       <div className="flex">
@@ -43,6 +52,7 @@ export const SetPipelineModelStep = (props: SetPipelineModelStepProps) => {
             }}
             initStoreOnCreate={false}
             accessToken={accessToken}
+            modelDefinitions={modelDefinitions}
           />
         )}
       </div>


### PR DESCRIPTION
Because

- query inside of the components like toolkit's form will make controlling the auth harder

This commit

- remove interior query
