### PR TITLE
feat: rollback to old createPipelineForm and add enabledQuery argument

### DIFF
--- a/packages/toolkit/src/view/destination/CreateDestinationForm.tsx
+++ b/packages/toolkit/src/view/destination/CreateDestinationForm.tsx
@@ -43,7 +43,7 @@ export type CreateDestinationFormProps = {
   onCreate: Nullable<(id: string) => void>;
   initStoreOnCreate: boolean;
   accessToken: Nullable<string>;
-  destinationDefinitions: Nullable<ConnectorDefinition[]>;
+  enabledQuery: boolean;
 } & Pick<FormRootProps, "width" | "marginBottom" | "formLess">;
 
 const selector = (state: CreateResourceFormStore) => ({
@@ -59,7 +59,7 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
     title,
     onCreate,
     initStoreOnCreate,
-    destinationDefinitions,
+    enabledQuery,
     accessToken,
     marginBottom,
     formLess,
@@ -86,11 +86,16 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
    * Get the destination definition and static state for fields
    * -----------------------------------------------------------------------*/
 
+  const destinationDefinitions = useDestinationDefinitions({
+    accessToken,
+    enabled: enabledQuery,
+  });
+
   const destinationOptions = React.useMemo(() => {
-    if (!destinationDefinitions) return [];
+    if (!destinationDefinitions.isSuccess) return [];
 
     if (pipelineMode === "MODE_ASYNC") {
-      return destinationDefinitions
+      return destinationDefinitions.data
         .filter(
           (e) =>
             e.name !== "destination-connector-definitions/destination-http" &&
@@ -116,7 +121,7 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
         }));
     }
 
-    return destinationDefinitions.map((e) => ({
+    return destinationDefinitions.data.map((e) => ({
       label: e.connector_definition.title,
       value: e.name,
       startIcon: (
@@ -509,8 +514,8 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
             setFieldErrors(null);
             setSelectedDestinationOption(option);
             setSelectedDestinationDefinition(
-              destinationDefinitions
-                ? destinationDefinitions.find(
+              destinationDefinitions.isSuccess
+                ? destinationDefinitions.data.find(
                     (e) => e.name === option?.value
                   ) ?? null
                 : null

--- a/packages/toolkit/src/view/model/CreateModelForm.tsx
+++ b/packages/toolkit/src/view/model/CreateModelForm.tsx
@@ -29,6 +29,7 @@ import {
   getInstillApiErrorMessage,
   useDeployModel,
   watchModel,
+  useModelDefinitions,
   type CreateGithubModelPayload,
   type CreateHuggingFaceModelPayload,
   type CreateArtivcModelPayload,
@@ -36,18 +37,17 @@ import {
   type Model,
   type Nullable,
   type CreateResourceFormStore,
-  ModelDefinition,
 } from "../../lib";
 import { checkUntilOperationIsDoen } from "../../lib/vdp-sdk/operation";
 
 export type CreateModelFormProps = {
   accessToken: Nullable<string>;
-  modelDefinitions: Nullable<ModelDefinition[]>;
   initStoreOnCreate: boolean;
   onCreate: Nullable<() => void>;
   disabledCreateModel?: boolean;
   width?: string;
   marginBottom?: string;
+  enabledQuery: boolean;
 };
 
 const selector = (state: CreateResourceFormStore) => ({
@@ -79,7 +79,7 @@ const selector = (state: CreateResourceFormStore) => ({
 export const CreateModelForm = (props: CreateModelFormProps) => {
   const {
     accessToken,
-    modelDefinitions,
+    enabledQuery,
     marginBottom,
     initStoreOnCreate,
     onCreate,
@@ -124,10 +124,15 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
    * Initialize the model definition
    * -----------------------------------------------------------------------*/
 
-  const modelDefinitionOptions = React.useMemo(() => {
-    if (!modelDefinitions) return [];
+  const modelDefinitions = useModelDefinitions({
+    enabled: enabledQuery,
+    accessToken,
+  });
 
-    return modelDefinitions.map((e) => {
+  const modelDefinitionOptions = React.useMemo(() => {
+    if (!modelDefinitions.isSuccess) return [];
+
+    return modelDefinitions.data.map((e) => {
       const { getIcon } = getModelDefinitionToolkit(e.name);
       return {
         label: e.title,

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/CreatePipelineForm.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/CreatePipelineForm.tsx
@@ -3,18 +3,9 @@ import * as React from "react";
 import { Nullable, useCreateResourceFormStore } from "../../../lib";
 import { CreatePipelineProgress } from "./CreatePipelineProgress";
 import { SetPipelineDetailsStep } from "./SetPipelineDetailsStep";
-import {
-  SetPipelineDestinationStep,
-  SetPipelineDestinationStepProps,
-} from "./SetPipelineDestinationStep";
-import {
-  SetPipelineModelStep,
-  SetPipelineModelStepProps,
-} from "./SetPipelineModelStep";
-import {
-  SetPipelineModeStep,
-  SetPipelineModeStepProps,
-} from "./SetPipelineModeStep";
+import { SetPipelineDestinationStep } from "./SetPipelineDestinationStep";
+import { SetPipelineModelStep } from "./SetPipelineModelStep";
+import { SetPipelineModeStep } from "./SetPipelineModeStep";
 
 //  Currently, we make number 0 & 1 stay at the first step
 //  0: Choose pipeline mode
@@ -29,12 +20,8 @@ export type CreatePipelineFormProps = {
   accessToken: Nullable<string>;
   syncModelOnly: boolean;
   withModelPreset: boolean;
-} & Pick<SetPipelineModeStepProps, "sources"> &
-  Pick<SetPipelineModelStepProps, "models" | "modelDefinitions"> &
-  Pick<
-    SetPipelineDestinationStepProps,
-    "destinationDefinitions" | "destinations"
-  >;
+  enabledQuery: boolean;
+};
 
 export const CreatePipelineForm = (props: CreatePipelineFormProps) => {
   const {
@@ -42,11 +29,7 @@ export const CreatePipelineForm = (props: CreatePipelineFormProps) => {
     accessToken,
     syncModelOnly,
     withModelPreset,
-    sources,
-    models,
-    modelDefinitions,
-    destinations,
-    destinationDefinitions,
+    enabledQuery,
   } = props;
   const pipelineFormStep = useCreateResourceFormStore(
     (state) => state.pipelineFormStep
@@ -60,7 +43,7 @@ export const CreatePipelineForm = (props: CreatePipelineFormProps) => {
           <SetPipelineModeStep
             syncModelOnly={syncModelOnly}
             accessToken={accessToken}
-            sources={sources}
+            enabledQuery={enabledQuery}
           />
         );
       case 2:
@@ -68,16 +51,14 @@ export const CreatePipelineForm = (props: CreatePipelineFormProps) => {
           <SetPipelineModelStep
             withModelPreset={withModelPreset}
             accessToken={accessToken}
-            models={models}
-            modelDefinitions={modelDefinitions}
+            enabledQuery={enabledQuery}
           />
         );
       case 3:
         return (
           <SetPipelineDestinationStep
             accessToken={accessToken}
-            destinations={destinations}
-            destinationDefinitions={destinationDefinitions}
+            enabledQuery={enabledQuery}
           />
         );
       case 4:
@@ -90,7 +71,14 @@ export const CreatePipelineForm = (props: CreatePipelineFormProps) => {
       default:
         return null;
     }
-  }, [pipelineFormStep, onCreate, accessToken, syncModelOnly, withModelPreset]);
+  }, [
+    pipelineFormStep,
+    onCreate,
+    accessToken,
+    syncModelOnly,
+    withModelPreset,
+    enabledQuery,
+  ]);
 
   return (
     <div className="flex flex-col">

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineDestinationStep/SelectExistingDestinationFlow.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineDestinationStep/SelectExistingDestinationFlow.tsx
@@ -10,10 +10,10 @@ import {
 import {
   useAmplitudeCtx,
   sendAmplitudeData,
+  useDestinations,
   useCreateResourceFormStore,
   type CreateResourceFormStore,
   type Nullable,
-  type DestinationWithDefinition,
 } from "../../../../lib";
 
 const selector = (state: CreateResourceFormStore) => ({
@@ -25,13 +25,14 @@ const selector = (state: CreateResourceFormStore) => ({
 
 export type SelectExistingDestinationFlowProps = {
   onSelect: () => void;
-  destinations: Nullable<DestinationWithDefinition[]>;
+  accessToken: Nullable<string>;
+  enabledQuery: boolean;
 };
 
 export const SelectExistingDestinationFlow = (
   props: SelectExistingDestinationFlowProps
 ) => {
-  const { onSelect, destinations } = props;
+  const { onSelect, accessToken, enabledQuery } = props;
   const { amplitudeIsInit } = useAmplitudeCtx();
 
   /* -------------------------------------------------------------------------
@@ -49,16 +50,21 @@ export const SelectExistingDestinationFlow = (
    * Get existing destinations and set up options
    * -----------------------------------------------------------------------*/
 
+  const destinations = useDestinations({
+    accessToken: accessToken,
+    enabled: enabledQuery,
+  });
+
   const [destinationOptions, setDestinationOptions] = React.useState<
     SingleSelectOption[] | null
   >(null);
 
   React.useEffect(() => {
-    if (!destinations) return;
+    if (!destinations.isSuccess) return;
 
     if (pipelineMode === "MODE_ASYNC") {
       setDestinationOptions(
-        destinations
+        destinations.data
           .filter(
             (e) =>
               e.name !== "destination-connectors/destination-http" &&
@@ -88,7 +94,7 @@ export const SelectExistingDestinationFlow = (
       );
     } else {
       setDestinationOptions(
-        destinations.map((e) => {
+        destinations.data.map((e) => {
           return {
             label: e.id,
             value: e.id,

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineDestinationStep/SetPipelineDestinationStep.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineDestinationStep/SetPipelineDestinationStep.tsx
@@ -12,21 +12,15 @@ import {
   useAmplitudeCtx,
   sendAmplitudeData,
   useCreateResourceFormStore,
+  useDestinations,
   type CreateDestinationPayload,
   type CreateResourceFormStore,
   type Nullable,
-  type DestinationWithDefinition,
 } from "../../../../lib";
 
 import { FormVerticalDivider } from "../FormVerticalDivider";
-import {
-  SelectExistingDestinationFlow,
-  SelectExistingDestinationFlowProps,
-} from "./SelectExistingDestinationFlow";
-import {
-  CreateDestinationForm,
-  CreateDestinationFormProps,
-} from "../../../destination";
+import { SelectExistingDestinationFlow } from "./SelectExistingDestinationFlow";
+import { CreateDestinationForm } from "../../../destination";
 
 const selector = (state: CreateResourceFormStore) => ({
   pipelineMode: state.fields.pipeline.mode,
@@ -41,13 +35,13 @@ const selector = (state: CreateResourceFormStore) => ({
 
 export type SetPipelineDestinationStepProps = {
   accessToken: Nullable<string>;
-} & Pick<SelectExistingDestinationFlowProps, "destinations"> &
-  Pick<CreateDestinationFormProps, "destinationDefinitions">;
+  enabledQuery: boolean;
+};
 
 export const SetPipelineDestinationStep = (
   props: SetPipelineDestinationStepProps
 ) => {
-  const { accessToken, destinations, destinationDefinitions } = props;
+  const { accessToken, enabledQuery } = props;
   const { amplitudeIsInit } = useAmplitudeCtx();
 
   /* -------------------------------------------------------------------------
@@ -73,6 +67,11 @@ export const SetPipelineDestinationStep = (
 
   const [selectedSyncDestinationOption, setSelectedSyncDestinationOption] =
     React.useState<SingleSelectOption | null>(null);
+
+  const destinations = useDestinations({
+    accessToken,
+    enabled: enabledQuery,
+  });
 
   React.useEffect(() => {
     const syncDestinationOptions = [
@@ -127,12 +126,12 @@ export const SetPipelineDestinationStep = (
   const createDestination = useCreateDestination();
 
   const handleGoNext = () => {
-    if (!destinations || !selectedSyncDestinationOption) {
+    if (!destinations.isSuccess || !selectedSyncDestinationOption) {
       return;
     }
 
     if (pipelineMode === "MODE_SYNC") {
-      const destinationIndex = destinations.findIndex(
+      const destinationIndex = destinations.data.findIndex(
         (e) => e.id === selectedSyncDestinationOption.value
       );
 
@@ -232,7 +231,8 @@ export const SetPipelineDestinationStep = (
               onSelect={() => {
                 increasePipelineFormStep();
               }}
-              destinations={destinations}
+              accessToken={accessToken}
+              enabledQuery={enabledQuery}
             />
           </div>
           <div className="flex">
@@ -253,7 +253,7 @@ export const SetPipelineDestinationStep = (
               formLess={true}
               initStoreOnCreate={false}
               accessToken={accessToken}
-              destinationDefinitions={destinationDefinitions}
+              enabledQuery={enabledQuery}
             />
           </div>
         </div>

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModeStep.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModeStep.tsx
@@ -8,7 +8,6 @@ import {
   type CreateResourceFormStore,
   type CreateSourcePayload,
   type Nullable,
-  SourceWithDefinition,
 } from "../../../lib";
 import {
   AsyncIcon,
@@ -33,11 +32,11 @@ const selector = (state: CreateResourceFormStore) => ({
 export type SetPipelineModeStepProps = {
   accessToken: Nullable<string>;
   syncModelOnly: boolean;
-  sources: Nullable<SourceWithDefinition[]>;
+  enabledQuery: boolean;
 };
 
 export const SetPipelineModeStep = (props: SetPipelineModeStepProps) => {
-  const { accessToken, syncModelOnly, sources } = props;
+  const { accessToken, syncModelOnly, enabledQuery } = props;
   const { amplitudeIsInit } = useAmplitudeCtx();
 
   /* -------------------------------------------------------------------------
@@ -56,6 +55,11 @@ export const SetPipelineModeStep = (props: SetPipelineModeStepProps) => {
   /* -------------------------------------------------------------------------
    * Initialize options
    * -----------------------------------------------------------------------*/
+
+  const sources = useSources({
+    accessToken,
+    enabled: enabledQuery,
+  });
 
   const [pipelineModeOptions, setPipelineModeOptions] = React.useState<
     SingleSelectOption[]
@@ -150,9 +154,9 @@ export const SetPipelineModeStep = (props: SetPipelineModeStepProps) => {
   }, [pipelineMode, selectedSyncSourceOption]);
 
   const handleGoNext = () => {
-    if (!sources || !selectedSyncSourceOption?.value) return;
+    if (!sources.isSuccess || !selectedSyncSourceOption?.value) return;
 
-    const sourceIndex = sources.findIndex(
+    const sourceIndex = sources.data.findIndex(
       (e) => e.id === selectedSyncSourceOption.value
     );
 

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModelStep/SetPipelineModelStep.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModelStep/SetPipelineModelStep.tsx
@@ -1,23 +1,16 @@
 import { FormVerticalDivider } from "../FormVerticalDivider";
-import {
-  SelectExistingModelFlow,
-  SelectExistingModelFlowProps,
-} from "./SelectExistingModelFlow";
-import {
-  CreateModelForm,
-  CreateModelFormProps,
-  CreateModelWithPresetForm,
-} from "../../../model";
+import { SelectExistingModelFlow } from "./SelectExistingModelFlow";
+import { CreateModelForm, CreateModelWithPresetForm } from "../../../model";
 import { useCreateResourceFormStore, type Nullable } from "../../../../lib";
 
 export type SetPipelineModelStepProps = {
   accessToken: Nullable<string>;
   withModelPreset: boolean;
-} & Pick<SelectExistingModelFlowProps, "models"> &
-  Pick<CreateModelFormProps, "modelDefinitions">;
+  enabledQuery: boolean;
+};
 
 export const SetPipelineModelStep = (props: SetPipelineModelStepProps) => {
-  const { accessToken, withModelPreset, models, modelDefinitions } = props;
+  const { accessToken, withModelPreset, enabledQuery } = props;
   const increasePipelineFormStep = useCreateResourceFormStore(
     (state) => state.increasePipelineFormStep
   );
@@ -30,7 +23,7 @@ export const SetPipelineModelStep = (props: SetPipelineModelStepProps) => {
             increasePipelineFormStep();
           }}
           accessToken={accessToken}
-          models={models}
+          enabledQuery={enabledQuery}
         />
       </div>
       <div className="flex">
@@ -52,7 +45,7 @@ export const SetPipelineModelStep = (props: SetPipelineModelStepProps) => {
             }}
             initStoreOnCreate={false}
             accessToken={accessToken}
-            modelDefinitions={modelDefinitions}
+            enabledQuery={enabledQuery}
           />
         )}
       </div>


### PR DESCRIPTION
Because

- we don't want to query data upfront

This commit

- rollback to old createPipelineForm and add enabledQuery argument
