### PR TITLE
fix: fix missing export of apiToken related query

### DIFF
--- a/packages/toolkit/src/lib/react-query-service/mgmt/index.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/index.ts
@@ -1,5 +1,7 @@
+export { useApiToken } from "./useApiToken";
 export { useApiTokens } from "./useApiTokens";
 export { useCreateApiToken } from "./useCreateApiToken";
+export { useDeleteApiToken } from "./useDeleteApiToken";
 export { useMgmtDefinition } from "./useMgmtDefinition";
 export { useUser } from "./useUser";
 export { useUpdateUser } from "./useUpdateUser";


### PR DESCRIPTION
Because

- we didn't correctly export useDeleteApiToken and useApiToken

This commit

- fix missing export of apiToken related query
