### PR TITLE
fix: fix configure profile form wrongly check user id

### DIFF
--- a/packages/toolkit/src/view/mgmt/ConfigureProfileForm/ConfigureProfileControl.tsx
+++ b/packages/toolkit/src/view/mgmt/ConfigureProfileForm/ConfigureProfileControl.tsx
@@ -53,18 +53,20 @@ export const ConfigureProfileControl = (
 
       validateConfigureProfileFormFieldSchema(fields);
 
-      // Check whether user id exist
-      const userIdExist = await checkUserIdExist({
-        id: fields.userName as string,
-        accessToken,
-      });
+      if (fields.userName !== instillUser.data.id) {
+        // Check whether user id exist
+        const userIdExist = await checkUserIdExist({
+          id: fields.userName as string,
+          accessToken,
+        });
 
-      if (userIdExist) {
-        setFieldError(
-          "userName",
-          "User ID already exists. Please try another one."
-        );
-        return;
+        if (userIdExist) {
+          setFieldError(
+            "userName",
+            "User ID already exists. Please try another one."
+          );
+          return;
+        }
       }
 
       setMessageBoxState(() => ({


### PR DESCRIPTION
Because

- we should not check username is exist if the username is the same

This commit

- fix configure profile form wrongly check user id
