### PR TITLE
fix: [INS-700] fix model repo description typo

### DIFF
--- a/packages/toolkit/src/lib/vdp-sdk/model/helper.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/model/helper.ts
@@ -41,7 +41,7 @@ export const modelHubPresetsList: ModelHubPreset[] = [
     task: "TASK_CLASSIFICATION",
     model_definition: "model-definitions/github",
     configuration: {
-      repository: "instill-ai/model-mobilenetv2",
+      repository: "instill-ai/model-mobilenetv2-dvc",
       tag: "v1.0-cpu",
     },
   },

--- a/packages/toolkit/src/view/model/CreateModelForm.tsx
+++ b/packages/toolkit/src/view/model/CreateModelForm.tsx
@@ -695,7 +695,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
               id="model-github-repo-url"
               label="GitHub repository"
               description="The name of a public GitHub repository, e.g.
-                      `instill-ai/model-mobilenetv2`."
+                      `instill-ai/model-mobilenetv2-dvc`."
               required={true}
               value={modelGithubRepoUrl}
               error={modelGithubRepoUrlError}

--- a/packages/toolkit/src/view/model/ModelConfigurationFields.tsx
+++ b/packages/toolkit/src/view/model/ModelConfigurationFields.tsx
@@ -23,7 +23,7 @@ export const ModelConfigurationFields = (
             id="model-github-repo-url"
             label="GitHub repository"
             description="The name of a public GitHub repository, e.g.
-                      `instill-ai/model-mobilenetv2`."
+                      `instill-ai/model-mobilenetv2-dvc`."
             required={true}
             value={model.configuration.repository}
             error={null}


### PR DESCRIPTION
Because

- "The name of a public GitHub repository, e.g. instill-ai/model-mobilenetv2." no longer available. Need to change to instill-ai/model-mobilenetv2-dvc.

This commit

-  fix model repo description typo
