### PR TITLE
fix: fix prefetch wrongly use queryClient

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.44.0",
+  "version": "0.44.1-rc.0",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/lib/react-query-service/connector/destination/prefetchDestinations.ts
+++ b/packages/toolkit/src/lib/react-query-service/connector/destination/prefetchDestinations.ts
@@ -1,12 +1,12 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
 import { Nullable } from "../../../type";
 import { fetchDestinations } from "./useDestinations";
 
 export async function prefetchDestinations(
+  queryClient: QueryClient,
   accessToken: Nullable<string>,
   staleTime?: number
 ) {
-  const queryClient = useQueryClient();
   await queryClient.prefetchQuery({
     queryKey: ["destinations"],
     queryFn: async () => {

--- a/packages/toolkit/src/lib/react-query-service/connector/source/prefetchSources.ts
+++ b/packages/toolkit/src/lib/react-query-service/connector/source/prefetchSources.ts
@@ -1,12 +1,12 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
 import { Nullable } from "../../../type";
 import { fetchSources } from "./useSources";
 
 export async function prefetchSources(
+  queryClient: QueryClient,
   accessToken: Nullable<string>,
   staleTime?: number
 ) {
-  const queryClient = useQueryClient();
   await queryClient.prefetchQuery({
     queryKey: ["sources"],
     queryFn: async () => {

--- a/packages/toolkit/src/lib/react-query-service/model/prefetchModels.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/prefetchModels.ts
@@ -1,12 +1,12 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
 import { fetchModels } from "./useModels";
 import { Nullable } from "../../type";
 
 export async function prefetchModels(
+  queryClient: QueryClient,
   accessToken: Nullable<string>,
   staleTime?: number
 ) {
-  const queryClient = useQueryClient();
   await queryClient.prefetchQuery({
     queryKey: ["models"],
     queryFn: async () => {

--- a/packages/toolkit/src/lib/react-query-service/pipeline/prefetchPipelines.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/prefetchPipelines.ts
@@ -1,12 +1,12 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
 import { Nullable } from "../../type";
 import { fetchPipelines } from "./usePipelines";
 
 export async function prefetchPipelines(
+  queryClient: QueryClient,
   accessToken: Nullable<string>,
   staleTime?: number
 ) {
-  const queryClient = useQueryClient();
   await queryClient.prefetchQuery({
     queryKey: ["pipelines"],
     queryFn: async () => {

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModeStep.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModeStep.tsx
@@ -6,6 +6,7 @@ import {
   useAmplitudeCtx,
   useCreateResourceFormStore,
   prefetchModels,
+  useQueryClient,
   type CreateResourceFormStore,
   type CreateSourcePayload,
   type Nullable,
@@ -39,6 +40,7 @@ export type SetPipelineModeStepProps = {
 export const SetPipelineModeStep = (props: SetPipelineModeStepProps) => {
   const { accessToken, syncModelOnly, enabledQuery } = props;
   const { amplitudeIsInit } = useAmplitudeCtx();
+  const queryClient = useQueryClient();
 
   /* -------------------------------------------------------------------------
    * Initialize form state
@@ -151,7 +153,7 @@ export const SetPipelineModeStep = (props: SetPipelineModeStepProps) => {
   const handleGoNext = async () => {
     if (!canGoNext) return;
 
-    prefetchModels(accessToken, 10 * 1000);
+    prefetchModels(queryClient, accessToken, 10 * 1000);
 
     const sourceIndex = sources.data.findIndex(
       (e) => e.id === selectedSyncSourceOption.value

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModelStep/SelectExistingModelFlow.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineModelStep/SelectExistingModelFlow.tsx
@@ -10,9 +10,10 @@ import {
   useAmplitudeCtx,
   sendAmplitudeData,
   useCreateResourceFormStore,
+  prefetchDestinations,
+  useQueryClient,
   type CreateResourceFormStore,
   type Nullable,
-  prefetchDestinations,
 } from "../../../../lib";
 
 const selector = (state: CreateResourceFormStore) => ({
@@ -31,6 +32,7 @@ export const SelectExistingModelFlow = (
 ) => {
   const { accessToken, onSelect, enabledQuery } = props;
   const { amplitudeIsInit } = useAmplitudeCtx();
+  const queryClient = useQueryClient();
 
   /* -------------------------------------------------------------------------
    * Initialize form state
@@ -82,7 +84,7 @@ export const SelectExistingModelFlow = (
       return;
     }
 
-    prefetchDestinations(accessToken, 10 * 1000);
+    prefetchDestinations(queryClient, accessToken, 10 * 1000);
 
     const targetModel = models.data.find(
       (e) => e.name === (selectedModelOption?.value as string)


### PR DESCRIPTION
Because

- prefetch function should digest queryClient from outside

This commit

-  fix prefetch wrongly use queryClient