### PR TITLE
remove shadows from semantic/colour and update radii names

### DIFF
--- a/packages/design-tokens/tokens/semantic/colour.json
+++ b/packages/design-tokens/tokens/semantic/colour.json
@@ -216,35 +216,5 @@
         "type": "color"
       }
     }
-  },
-  "shadow": {
-    "xxs-shadow": {
-      "value": "{Shadows.Shadow-100}",
-      "type": "boxShadow"
-    },
-    "xs-shadow": {
-      "value": "{Shadows.Shadow-200}",
-      "type": "boxShadow"
-    },
-    "sm-shadow": {
-      "value": "{Shadows.Shadow-300}",
-      "type": "boxShadow"
-    },
-    "md-shadow": {
-      "value": "{Shadows.Shadow-400}",
-      "type": "boxShadow"
-    },
-    "lg-shadow": {
-      "value": "{Shadows.Shadow-500}",
-      "type": "boxShadow"
-    },
-    "xl-shadow": {
-      "value": "{Shadows.Shadow-600}",
-      "type": "boxShadow"
-    },
-    "xxl-shadow": {
-      "value": "{Shadows.Shadow-700}",
-      "type": "boxShadow"
-    }
   }
 }

--- a/packages/design-tokens/tokens/semantic/comp.json
+++ b/packages/design-tokens/tokens/semantic/comp.json
@@ -12,15 +12,15 @@
       "value": "{s}",
       "type": "borderRadius"
     },
-    "s": {
+    "sm": {
       "value": "{m}",
       "type": "borderRadius"
     },
-    "m": {
+    "md": {
       "value": "{l}",
       "type": "borderRadius"
     },
-    "l": {
+    "lg": {
       "value": "{xl}",
       "type": "borderRadius"
     },


### PR DESCRIPTION
Because

- Fix token collision by removing shadows from semantic/colour
- update radii name

This commit

- Fix token collision by removing shadows from semantic/colour
- update radii name
