### PR TITLE
fix(design-tokens): fix design tokens initial version

### DIFF
--- a/release-please/manifest.json
+++ b/release-please/manifest.json
@@ -1,1 +1,1 @@
-{"packages/design-system":"0.10.6", "packages/design-tokens":"0.0.0","packages/eslint-config-cortex":"0.4.0","packages/toolkit":"0.44.3"}
+{"packages/design-system":"0.10.6", "packages/design-tokens":"0.0.0-alpha","packages/eslint-config-cortex":"0.4.0","packages/toolkit":"0.44.3"}


### PR DESCRIPTION
Because

- design tokens initial version is wrong

This commit

- fix design tokens initial version
