### PR TITLE
chore(design-tokens): extend style instead of replace them in design-tokens tailwind configuration

### DIFF
--- a/packages/design-tokens/src/buildTailwindPreset.ts
+++ b/packages/design-tokens/src/buildTailwindPreset.ts
@@ -47,21 +47,23 @@ async function main() {
 
   const configuration = `module.exports = {
     theme: {
-      colors: {
-        ${semanticColours
-          .map((e) => `"${e.name}": "var(--${e.name})"`)
-          .join(",\n")}
-      },
-      boxShadow: {
-        ${semanticBoxShadow
-          .map((e) => `"${e.name.split("-")[1]}": "var(--${e.name})"`)
-          .join(",\n")}
-      },
-      fontFamily: {${fontFamiliesString}},
-      borderWidth: {${borderWitdhString}},
-      opacity: {${opacityString}},
-      spacing: {${spacingString}},
-      borderRadius: {${borderRadiusString}}
+      extend: {
+        colors: {
+          ${semanticColours
+            .map((e) => `"${e.name}": "var(--${e.name})"`)
+            .join(",\n")}
+        },
+        boxShadow: {
+          ${semanticBoxShadow
+            .map((e) => `"${e.name.split("-")[1]}": "var(--${e.name})"`)
+            .join(",\n")}
+        },
+        fontFamily: {${fontFamiliesString}},
+        borderWidth: {${borderWitdhString}},
+        opacity: {${opacityString}},
+        spacing: {${spacingString}},
+        borderRadius: {${borderRadiusString}}
+      }
     },
     plugins: [
       ({ addUtilities }) => {


### PR DESCRIPTION
Because

- We should not replace all tailwind default styles

This commit

- extend style instead of replace them in design-tokens tailwind configuration
