### PR TITLE
fix(design-tokens): fix spacing tokens to align with Tailwind convention

### DIFF
--- a/packages/design-tokens/tokens/global.json
+++ b/packages/design-tokens/tokens/global.json
@@ -1,18 +1,34 @@
 {
   "base": {
     "0": {
+      "5": {
+        "value": "2px",
+        "type": "spacing"
+      },
       "value": "0px",
       "type": "spacing"
     },
     "1": {
+      "5": {
+        "value": "6px",
+        "type": "spacing"
+      },
       "value": "4px",
       "type": "spacing"
     },
     "2": {
+      "5": {
+        "value": "10px",
+        "type": "spacing"
+      },
       "value": "8px",
       "type": "spacing"
     },
     "3": {
+      "5": {
+        "value": "14px",
+        "type": "spacing"
+      },
       "value": "12px",
       "type": "spacing"
     },
@@ -29,63 +45,99 @@
       "type": "spacing"
     },
     "7": {
-      "value": "32px",
+      "value": "28px",
       "type": "spacing"
     },
     "8": {
-      "value": "40px",
+      "value": "32px",
       "type": "spacing"
     },
     "9": {
-      "value": "48px",
+      "value": "36px",
       "type": "spacing"
     },
     "10": {
-      "value": "56px",
+      "value": "40px",
       "type": "spacing"
     },
     "11": {
-      "value": "64px",
+      "value": "44px",
       "type": "spacing"
     },
     "12": {
-      "value": "72px",
-      "type": "spacing"
-    },
-    "13": {
-      "value": "80px",
+      "value": "48px",
       "type": "spacing"
     },
     "14": {
-      "value": "88px",
-      "type": "spacing"
-    },
-    "15": {
-      "value": "96px",
+      "value": "56px",
       "type": "spacing"
     },
     "16": {
-      "value": "112px",
-      "type": "spacing"
-    },
-    "17": {
-      "value": "128px",
-      "type": "spacing"
-    },
-    "18": {
-      "value": "160px",
-      "type": "spacing"
-    },
-    "19": {
-      "value": "192px",
+      "value": "64px",
       "type": "spacing"
     },
     "20": {
+      "value": "80px",
+      "type": "spacing"
+    },
+    "24": {
+      "value": "96px",
+      "type": "spacing"
+    },
+    "28": {
+      "value": "112px",
+      "type": "spacing"
+    },
+    "32": {
+      "value": "128px",
+      "type": "spacing"
+    },
+    "36": {
+      "value": "144px",
+      "type": "spacing"
+    },
+    "40": {
+      "value": "160px",
+      "type": "spacing"
+    },
+    "44": {
+      "value": "176px",
+      "type": "spacing"
+    },
+    "48": {
+      "value": "192px",
+      "type": "spacing"
+    },
+    "52": {
+      "value": "208px",
+      "type": "spacing"
+    },
+    "56": {
       "value": "224px",
       "type": "spacing"
     },
-    "21": {
+    "60": {
+      "value": "240px",
+      "type": "spacing"
+    },
+    "64": {
       "value": "256px",
+      "type": "spacing"
+    },
+    "72": {
+      "value": "288px",
+      "type": "spacing"
+    },
+    "80": {
+      "value": "320px",
+      "type": "spacing"
+    },
+    "96": {
+      "value": "384px",
+      "type": "spacing"
+    },
+    "px": {
+      "value": "1px",
       "type": "spacing"
     },
     "Text+Icon": {

--- a/packages/design-tokens/tokens/global.json
+++ b/packages/design-tokens/tokens/global.json
@@ -1,34 +1,18 @@
 {
   "base": {
     "0": {
-      "5": {
-        "value": "2px",
-        "type": "spacing"
-      },
       "value": "0px",
       "type": "spacing"
     },
     "1": {
-      "5": {
-        "value": "6px",
-        "type": "spacing"
-      },
       "value": "4px",
       "type": "spacing"
     },
     "2": {
-      "5": {
-        "value": "10px",
-        "type": "spacing"
-      },
       "value": "8px",
       "type": "spacing"
     },
     "3": {
-      "5": {
-        "value": "14px",
-        "type": "spacing"
-      },
       "value": "12px",
       "type": "spacing"
     },
@@ -138,6 +122,22 @@
     },
     "px": {
       "value": "1px",
+      "type": "spacing"
+    },
+    "0,5": {
+      "value": "2px",
+      "type": "spacing"
+    },
+    "1,5": {
+      "value": "6px",
+      "type": "spacing"
+    },
+    "2,5": {
+      "value": "10px",
+      "type": "spacing"
+    },
+    "3,5": {
+      "value": "14px",
       "type": "spacing"
     },
     "Text+Icon": {

--- a/packages/design-tokens/tokens/semantic/comp.json
+++ b/packages/design-tokens/tokens/semantic/comp.json
@@ -90,40 +90,28 @@
       "value": "{base.12}",
       "type": "spacing"
     },
-    "spacing-13": {
-      "value": "{base.13}",
-      "type": "spacing"
-    },
     "spacing-14": {
       "value": "{base.14}",
-      "type": "spacing"
-    },
-    "spacing-15": {
-      "value": "{base.15}",
       "type": "spacing"
     },
     "spacing-16": {
       "value": "{base.16}",
       "type": "spacing"
     },
-    "spacing-17": {
-      "value": "{base.17}",
-      "type": "spacing"
-    },
-    "spacing-18": {
-      "value": "{base.18}",
-      "type": "spacing"
-    },
-    "spacing-19": {
-      "value": "{base.19}",
-      "type": "spacing"
-    },
     "spacing-20": {
       "value": "{base.20}",
       "type": "spacing"
     },
-    "spacing-21": {
-      "value": "{base.21}",
+    "spacing-24": {
+      "value": "{base.24}",
+      "type": "spacing"
+    },
+    "spacing-28": {
+      "value": "{base.28}",
+      "type": "spacing"
+    },
+    "spacing-32": {
+      "value": "{base.32}",
       "type": "spacing"
     }
   },

--- a/packages/design-tokens/tokens/theme/dark.json
+++ b/packages/design-tokens/tokens/theme/dark.json
@@ -26,6 +26,10 @@
       "alt-primary": {
         "value": "{base.neutral.600}",
         "type": "color"
+      },
+      "disabled": {
+        "value": "{base.neutral.600}",
+        "type": "color"
       }
     },
     "fg": {

--- a/packages/design-tokens/tokens/theme/light.json
+++ b/packages/design-tokens/tokens/theme/light.json
@@ -26,6 +26,10 @@
       "alt-primary": {
         "value": "{base.neutral.600}",
         "type": "color"
+      },
+      "disabled": {
+        "value": "{base.neutral.100}",
+        "type": "color"
       }
     },
     "fg": {


### PR DESCRIPTION
Because

- Spacing token was confusing and was conflicting with Tailwind naming convention

This commit

- Make spacing token align with Tailwind
- add disabled bg on semantic level
