### PR TITLE
fix(design-tokens): use CSS variables to set up fontFamily

### DIFF
--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -1,7 +1,17 @@
 
 ## Preface
 
-To speed up the development, avoid the silo effect between the design and development teams, and reduce the cost of the development(especially the light/dark theme). We decide to embrace a set rule of design tokens. [^1]
+Normally, what big company does not necessarily mean it will fit into a small and agile startup. Design tokens are not in that category and it will benefit our developer cycle in the long run. Let’s bring some examples here
+
+- Color, we are using lots of color on our website and console. These colors usually are represented with hex values like #FFFFFF. This hex value doesn’t have any explicit meaning and is hard to remember. But with design-tokens, we can transfer them into something more verbose like primary, secondary…etc
+- Light and Dark theme: Under the context of TailwindCSS, the way to implement the light/dark theme is normally with the help of a special utility class like bg-white dark:bg-black and when we switch the className at the root element from “” to “dark” the style will change. But this will cost us to set up all these color pairs again and again. Which makes sense when the project is small but not efficient when the project begins to grow. Right now we are using CSS variables and TailwindCSS together to accomplish this. (We can accomplish this without the help of Design-Tokens, but design-tokens bring us a much more stable platform to work with. So Dani Sosa and I take this opportunity) Later on, all we need to do is switch the data-theme at the root with a single color utility class set to enable dark mode
+- Style tracing and versioning: The design-tokens are stored in our Github repo and version controlled.
+
+There are lots of other minor goodies like
+
+- Fast typography setup
+- GitHub CI/CD for testing style conflict
+- Additional abstraction to encapsulate styles
 
 ## Package structure
 

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -109,8 +109,36 @@ Toggle the theme in the app
 </button>
 ```
 
-## How to use the font with Nextjs optimization
+## How to set up the font 
 
+Import the Google font in the Head
+
+```html
+<head>
+  <link
+    rel="preconnect"
+    href="https://fonts.googleapis.com"
+    as="font"
+    crossOrigin=""
+  />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+</head>
+```
+
+Set up the CSS variables
+
+```
+:root {
+  --font-ibm-plex-sans: "IBM Plex Sans", sans-serif;
+}
+```
+
+
+
+## How to use the font with Nextjs optimization
 
 You need to first check all the CSS variables related to FontFamily in the TailwindCSS preset, and add the CSS variable at the root of your Nextjs APP. Take IBM Plex Sans as an example. The TailwindCSS preset looks like
 

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -109,6 +109,44 @@ Toggle the theme in the app
 </button>
 ```
 
+## How to use the font with Nextjs optimization
+
+
+You need to first check all the CSS variables related to FontFamily in the TailwindCSS preset, and add the CSS variable at the root of your Nextjs APP. Take IBM Plex Sans as an example. The TailwindCSS preset looks like
+
+```js
+module.exports = {
+  theme: {
+    fontFamily: {
+      "ibm-plex-sans": "var(--font-ibm-plex-sans)"
+    },
+  }
+}
+```
+
+You need to set the font optimization according to the identifier `--font-ibm-plex-sans`
+
+```ts
+// pages/_app.tsx
+import { IBM_Plex_Sans } from "next/font/google";
+import { Inter } from 'next/font/google';
+ 
+const ibmPlexSans = IBM_Plex_Sans({
+  style: ["italic", "normal"],
+  weight: ["100", "200", "300", "400", "500", "600", "700"],
+  subsets: ["latin"],
+  variable: '--font-ibm-plex-sans',
+});
+ 
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <main className={`${inter.variable} font-sans`}>
+      <Component {...pageProps} />
+    </main>
+  );
+}
+```
+
 ## Technological details 
 
 ### The Tokens Studio's token

--- a/packages/design-tokens/src/buildTailwindPreset.ts
+++ b/packages/design-tokens/src/buildTailwindPreset.ts
@@ -36,7 +36,14 @@ async function main() {
 
   const fontFamilies = tokens.filter((e) => e.type === "fontFamilies");
   const fontFamiliesString = fontFamilies
-    .map((e) => `"${e.name.replace("font-families-", "")}": "${e.value}"`)
+    .map(
+      (e) =>
+        `"${e.name.replace("font-families-", "")}": "var(--font-${(
+          e.value as string
+        )
+          .replaceAll(" ", "-")
+          .toLowerCase()})"`
+    )
     .join(",\n");
 
   const typography = tokens.filter((e) => e.type === "typography");
@@ -56,6 +63,9 @@ async function main() {
         textIndent: paragraphIndent,
         paragraphIndent: undefined,
         paragraphSpacing: undefined,
+        fontFamily: `var(--font-${value.fontFamily
+          .replaceAll(" ", "-")
+          .toLowerCase()})`,
       })}`;
     }
 
@@ -69,6 +79,9 @@ async function main() {
         textIndent: paragraphIndent,
         paragraphIndent: undefined,
         paragraphSpacing: undefined,
+        fontFamily: `var(--font-${value.fontFamily
+          .replaceAll(" ", "-")
+          .toLowerCase()})`,
       })}`;
     }
 
@@ -82,6 +95,9 @@ async function main() {
         textIndent: paragraphIndent,
         paragraphIndent: undefined,
         paragraphSpacing: undefined,
+        fontFamily: `var(--font-${value.fontFamily
+          .replaceAll(" ", "-")
+          .toLowerCase()})`,
       })}`;
     }
 
@@ -95,6 +111,9 @@ async function main() {
         textIndent: paragraphIndent,
         paragraphIndent: undefined,
         paragraphSpacing: undefined,
+        fontFamily: `var(--font-${value.fontFamily
+          .replaceAll(" ", "-")
+          .toLowerCase()})`,
       })}`;
     }
 
@@ -106,6 +125,9 @@ async function main() {
         textIndent: paragraphIndent,
         paragraphIndent: undefined,
         paragraphSpacing: undefined,
+        fontFamily: `var(--font-${value.fontFamily
+          .replaceAll(" ", "-")
+          .toLowerCase()})`,
       })}`;
     }
   });


### PR DESCRIPTION
Because

- In order to use Nextjs font optimization with TailwindCSS we need to use CSS variables

This commit

- use CSS variables to set up fontFamily
