### PR TITLE
chore(toolkit): adopt new connector definition format

### DIFF
--- a/packages/toolkit/src/components/cells/ConnectionTypeCell.tsx
+++ b/packages/toolkit/src/components/cells/ConnectionTypeCell.tsx
@@ -22,6 +22,7 @@ export const ConnectionTypeCell = ({
   width,
   padding,
 }: ConnectionTypeCellProps) => {
+  console.log(11111, connectorDefinition)
   return (
     <td>
       <div className={cn("py-2.5", width, padding)}>
@@ -29,9 +30,7 @@ export const ConnectionTypeCell = ({
           <div className="flex flex-row gap-x-[5px]">
             <ImageWithFallback
               src={
-                connectorDefinition.connector_definition.docker_repository.split(
-                  "/"
-                )[0] === "airbyte"
+                connectorDefinition.id.startsWith("airbyte")
                   ? `/icons/airbyte/${connectorDefinition.connector_definition.icon}`
                   : `/icons/instill/${connectorDefinition.connector_definition.icon}`
               }

--- a/packages/toolkit/src/components/cells/ConnectionTypeCell.tsx
+++ b/packages/toolkit/src/components/cells/ConnectionTypeCell.tsx
@@ -22,7 +22,6 @@ export const ConnectionTypeCell = ({
   width,
   padding,
 }: ConnectionTypeCellProps) => {
-  console.log(11111, connectorDefinition)
   return (
     <td>
       <div className={cn("py-2.5", width, padding)}>

--- a/packages/toolkit/src/lib/react-query-service/connector/source/useSourceWithPipelines.ts
+++ b/packages/toolkit/src/lib/react-query-service/connector/source/useSourceWithPipelines.ts
@@ -93,17 +93,11 @@ const tt = {
                 "source-connector-definitions/source-grpc",
               source_connector_definition_detail: {
                 connector_definition: {
-                  create_time: "2023-05-26T09:20:29.403416Z",
-                  docker_repository: "instill-ai/source-grpc",
                   documentation_url:
                     "https://www.instill.tech/docs/source-connectors/grpc",
                   icon: "grpc.svg",
                   public: true,
-                  release_date: {},
-                  release_stage: "RELEASE_STAGE_GENERALLY_AVAILABLE",
-                  resource_requirements: {},
                   title: "gRPC",
-                  update_time: "2023-05-26T09:20:29.403416Z",
                 },
                 id: "source-grpc",
                 name: "source-connector-definitions/source-grpc",
@@ -215,18 +209,11 @@ const tt = {
                 "destination-connector-definitions/destination-google-sheets",
               destination_connector_definition_detail: {
                 connector_definition: {
-                  create_time: "2023-05-26T09:20:29.523499Z",
-                  docker_image_tag: "0.1.1",
-                  docker_repository: "airbyte/destination-google-sheets",
                   documentation_url:
                     "https://docs.airbyte.io/integrations/destinations/google-sheets",
                   icon: "google-sheets.svg",
                   public: true,
-                  release_date: {},
-                  release_stage: "RELEASE_STAGE_ALPHA",
-                  resource_requirements: {},
                   title: "Google Sheets",
-                  update_time: "2023-05-26T09:20:29.523499Z",
                 },
                 id: "destination-google-sheets",
                 name: "destination-connector-definitions/destination-google-sheets",
@@ -272,17 +259,11 @@ const tt = {
                 "source-connector-definitions/source-http",
               source_connector_definition_detail: {
                 connector_definition: {
-                  create_time: "2023-05-26T09:20:29.399803Z",
-                  docker_repository: "instill-ai/source-http",
                   documentation_url:
                     "https://www.instill.tech/docs/source-connectors/http",
                   icon: "http.svg",
                   public: true,
-                  release_date: {},
-                  release_stage: "RELEASE_STAGE_GENERALLY_AVAILABLE",
-                  resource_requirements: {},
                   title: "HTTP",
-                  update_time: "2023-05-26T09:20:29.399803Z",
                 },
                 id: "source-http",
                 name: "source-connector-definitions/source-http",
@@ -394,17 +375,11 @@ const tt = {
                 "destination-connector-definitions/destination-http",
               destination_connector_definition_detail: {
                 connector_definition: {
-                  create_time: "2023-05-26T09:20:29.405093Z",
-                  docker_repository: "instill-ai/destination-http",
                   documentation_url:
                     "https://www.instill.tech/docs/destination-connectors/http",
                   icon: "http.svg",
                   public: true,
-                  release_date: {},
-                  release_stage: "RELEASE_STAGE_GENERALLY_AVAILABLE",
-                  resource_requirements: {},
                   title: "HTTP",
-                  update_time: "2023-05-26T09:20:29.405093Z",
                 },
                 id: "destination-http",
                 name: "destination-connector-definitions/destination-http",

--- a/packages/toolkit/src/lib/vdp-sdk/connector/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/connector/types.ts
@@ -26,33 +26,16 @@ export type ConnectorDefinition = {
   id: string;
   connector_definition: {
     title: string;
-    docker_repository: string;
-    docker_image_tag: string;
     documentation_url: string;
     icon: string;
     connection_type: string;
     spec: {
       documentation_url: string;
-      changelog_url?: string;
       connection_specification: JSONSchema7;
-      supports_incremental: boolean;
-      supports_normalization: boolean;
-      supports_dbt: boolean;
-      supported_destination_sync_modes: string[];
-      advanced_auth: Nullable<Record<string, any>>;
     };
     tombstone: boolean;
     public: boolean;
     custom: boolean;
-    release_stage: string;
-    release_date: {
-      year: number;
-      month: number;
-      day: number;
-    };
-    resource_requirements: Record<string, any>;
-    create_time: string;
-    update_time: string;
   };
 };
 

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/mocks.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/mocks.ts
@@ -30,17 +30,11 @@ export const mockPipeline: Pipeline = {
             "source-connector-definitions/source-http",
           source_connector_definition_detail: {
             connector_definition: {
-              create_time: "2023-05-16T02:43:06.336673Z",
-              docker_repository: "instill-ai/source-http",
               documentation_url:
                 "https://www.instill.tech/docs/source-connectors/http",
               icon: "http.svg",
               public: true,
-              release_date: {},
-              release_stage: "RELEASE_STAGE_GENERALLY_AVAILABLE",
-              resource_requirements: {},
               title: "HTTP",
-              update_time: "2023-05-16T02:43:06.336673Z",
             },
             id: "source-http",
             name: "source-connector-definitions/source-http",
@@ -238,17 +232,11 @@ export const mockPipeline: Pipeline = {
             "destination-connector-definitions/destination-http",
           destination_connector_definition_detail: {
             connector_definition: {
-              create_time: "2023-05-16T02:43:06.342962Z",
-              docker_repository: "instill-ai/destination-http",
               documentation_url:
                 "https://www.instill.tech/docs/destination-connectors/http",
               icon: "http.svg",
               public: true,
-              release_date: {},
-              release_stage: "RELEASE_STAGE_GENERALLY_AVAILABLE",
-              resource_requirements: {},
               title: "HTTP",
-              update_time: "2023-05-16T02:43:06.342962Z",
             },
             id: "destination-http",
             name: "destination-connector-definitions/destination-http",

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
@@ -65,22 +65,10 @@ export type DestinationComponent = {
 
 export type PipelineConnectorComponentDefinition = {
   connector_definition: {
-    create_time: string;
-    docker_repository: string;
     documentation_url: string;
     icon: string;
     public: boolean;
-    release_date:
-      | {
-          year: number;
-          month: number;
-          day: number;
-        }
-      | {};
-    release_stage: string;
-    resource_requirements: Record<string, any>;
     title: string;
-    update_time: string;
   };
   id: string;
   name: string;

--- a/packages/toolkit/src/view/destination/ConfigureDestinationForm.tsx
+++ b/packages/toolkit/src/view/destination/ConfigureDestinationForm.tsx
@@ -90,10 +90,8 @@ export const ConfigureDestinationForm = (
 
   const isSyncDestination = React.useMemo(() => {
     if (
-      destination.destination_connector_definition.connector_definition
-        .docker_repository === "instill-ai/destination-grpc" ||
-      destination.destination_connector_definition.connector_definition
-        .docker_repository === "instill-ai/destination-http"
+      destination.destination_connector_definition.id === "destination-grpc" ||
+      destination.destination_connector_definition.id === "destination-http"
     ) {
       return true;
     }
@@ -109,9 +107,7 @@ export const ConfigureDestinationForm = (
       startIcon: (
         <ImageWithFallback
           src={
-            destination.destination_connector_definition.connector_definition.docker_repository.split(
-              "/"
-            )[0] === "airbyte"
+            destination.destination_connector_definition.id.startsWith("airbyte")
               ? `/icons/airbyte/${destination.destination_connector_definition.connector_definition.icon}`
               : `/icons/instill/${destination.destination_connector_definition.connector_definition.icon}`
           }
@@ -203,10 +199,8 @@ export const ConfigureDestinationForm = (
 
   const handleSubmit = React.useCallback(async () => {
     if (
-      destination.destination_connector_definition.connector_definition
-        .docker_repository === "instill-ai/destination-grpc" ||
-      destination.destination_connector_definition.connector_definition
-        .docker_repository === "instill-ai/destination-http"
+      destination.id === "destination-grpc" ||
+      destination.id === "destination-http"
     ) {
       return;
     }
@@ -328,8 +322,6 @@ export const ConfigureDestinationForm = (
     setCanEdit,
     airbyteFormIsDirty,
     setAirbyteFormIsDirty,
-    destination.destination_connector_definition.connector_definition
-      .docker_repository,
     destination.name,
     updateDestination,
     init,

--- a/packages/toolkit/src/view/destination/CreateDestinationForm.tsx
+++ b/packages/toolkit/src/view/destination/CreateDestinationForm.tsx
@@ -106,8 +106,7 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
             <Image
               className="my-auto"
               src={
-                e.connector_definition.docker_repository.split("/")[0] ===
-                "airbyte"
+                e.id.startsWith("airbyte")
                   ? `/icons/airbyte/${e.connector_definition.icon}`
                   : `/icons/instill/${e.connector_definition.icon}`
               }
@@ -125,7 +124,7 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
       startIcon: (
         <ImageWithFallback
           src={
-            e.connector_definition.docker_repository.split("/")[0] === "airbyte"
+            e.id.startsWith("airbyte")
               ? `/icons/airbyte/${e.connector_definition.icon}`
               : `/icons/instill/${e.connector_definition.icon}`
           }
@@ -156,10 +155,8 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
     if (!selectedDestinationDefinition) return true;
 
     if (
-      selectedDestinationDefinition.connector_definition.docker_repository ===
-        "instill-ai/destination-grpc" ||
-      selectedDestinationDefinition.connector_definition.docker_repository ===
-        "instill-ai/destination-http"
+      selectedDestinationDefinition.id === "destination-grpc" ||
+      selectedDestinationDefinition.id === "destination-http"
     ) {
       return false;
     } else {
@@ -171,15 +168,13 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
     if (!selectedDestinationDefinition) return null;
 
     if (
-      selectedDestinationDefinition.connector_definition.docker_repository ===
-      "instill-ai/destination-grpc"
+      selectedDestinationDefinition.id === "destination-grpc"
     ) {
       return "destination-grpc";
     }
 
     if (
-      selectedDestinationDefinition.connector_definition.docker_repository ===
-      "instill-ai/destination-http"
+      selectedDestinationDefinition.id === "destination-http"
     ) {
       return "destination-http";
     }
@@ -332,8 +327,7 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
     // our own payload
 
     if (
-      selectedDestinationDefinition?.connector_definition.docker_repository ===
-      "instill-ai/destination-grpc"
+      selectedDestinationDefinition?.id === "destination-grpc"
     ) {
       payload = {
         id: "destination-grpc",
@@ -346,8 +340,7 @@ export const CreateDestinationForm = (props: CreateDestinationFormProps) => {
         },
       };
     } else if (
-      selectedDestinationDefinition?.connector_definition.docker_repository ===
-      "instill-ai/destination-http"
+      selectedDestinationDefinition?.id === "destination-http"
     ) {
       payload = {
         id: "destination-http",

--- a/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineDestinationStep/SelectExistingDestinationFlow.tsx
+++ b/packages/toolkit/src/view/pipeline/CreatePipelineForm/SetPipelineDestinationStep/SelectExistingDestinationFlow.tsx
@@ -78,9 +78,7 @@ export const SelectExistingDestinationFlow = (
                 <Image
                   className="my-auto"
                   src={
-                    e.destination_connector_definition.connector_definition.docker_repository.split(
-                      "/"
-                    )[0] === "airbyte"
+                    e.destination_connector_definition.id.startsWith("airbyte")
                       ? `/icons/airbyte/${e.destination_connector_definition.connector_definition.icon}`
                       : `/icons/instill/${e.destination_connector_definition.connector_definition.icon}`
                   }


### PR DESCRIPTION
Because

- the backend connector-definition format has been updated in order to support more connectors in future

This commit

- adopt new connector definition format
