### PR TITLE
fix(toolkit): fix connector definition type

### DIFF
--- a/packages/toolkit/src/lib/vdp-sdk/connector/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/connector/types.ts
@@ -37,6 +37,7 @@ export type ConnectorDefinition = {
     public: boolean;
     custom: boolean;
     vendor: string;
+    vendor_attributes: JSONSchema7;
   };
 };
 

--- a/packages/toolkit/src/lib/vdp-sdk/connector/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/connector/types.ts
@@ -28,7 +28,7 @@ export type ConnectorDefinition = {
     title: string;
     documentation_url: string;
     icon: string;
-    connection_type: string;
+    icon_url: string;
     spec: {
       documentation_url: string;
       connection_specification: JSONSchema7;
@@ -36,6 +36,7 @@ export type ConnectorDefinition = {
     tombstone: boolean;
     public: boolean;
     custom: boolean;
+    vendor: string;
   };
 };
 


### PR DESCRIPTION
Because

- vendor and vendor_attributes are missing in connector definition

This commit

-  fix connector definition type
