### PR TITLE
fix(design-system): remove Dialog.Close in the Dialog.Content

### DIFF
--- a/packages/design-system/src/new-ui/Dialog/Dialog.stories.tsx
+++ b/packages/design-system/src/new-ui/Dialog/Dialog.stories.tsx
@@ -1,14 +1,16 @@
-import { Meta, StoryFn } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import { Dialog } from "./Dialog";
 
-const meta: Meta = {
+const meta: Meta<typeof Dialog> = {
   title: "Components/NewUi/Dialog",
 };
 
 export default meta;
 
-const Template: StoryFn = () => {
-  return (
+type Story = StoryObj<typeof Dialog>;
+
+export const Regular: Story = {
+  render: () => (
     <Dialog.Root>
       <Dialog.Trigger asChild>
         <button>Open Dialog</button>
@@ -31,9 +33,5 @@ const Template: StoryFn = () => {
         <Dialog.Close />
       </Dialog.Content>
     </Dialog.Root>
-  );
+  ),
 };
-
-export const Playground: StoryFn<typeof Dialog> = Template.bind({});
-
-Playground.args = {};

--- a/packages/design-system/src/new-ui/Dialog/Dialog.tsx
+++ b/packages/design-system/src/new-ui/Dialog/Dialog.tsx
@@ -52,10 +52,6 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-semantic-accent-hover focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
-        <Icons.X className="w-5 h-5 stroke-semantic-fg-primary" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
 ));


### PR DESCRIPTION
Because

- Dialog.Close should not be inside the Dialog.Content

This commit

- remove Dialog.Close in the Dialog.Content
