### PR TITLE
feat(toolkit): add rename pipeline mutation and react-query hook

### DIFF
--- a/packages/toolkit/src/lib/react-query-service/pipeline/index.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/index.ts
@@ -3,6 +3,7 @@ export * from "./useCreatePipeline";
 export * from "./usePipeline";
 export * from "./usePipelines";
 export * from "./usePipelineSchema";
+export * from "./useRenamePipeline";
 export * from "./useUpdatePipeline";
 export * from "./useDeletePipeline";
 export * from "./useActivatePipeline";

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useRenamePipeline.tsx
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useRenamePipeline.tsx
@@ -1,0 +1,75 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Nullable } from "../../type";
+import {
+  renamePipelineMutation,
+  watchPipeline,
+  type Pipeline,
+  type PipelinesWatchState,
+  type PipelineWatchState,
+  type RenamePipelinePayload,
+} from "../../vdp-sdk";
+import { removeObjKey } from "../../utility";
+
+export const useRenamePipeline = () => {
+  const queryClient = useQueryClient();
+  return useMutation(
+    async ({
+      payload,
+      accessToken,
+    }: {
+      payload: RenamePipelinePayload;
+      accessToken: Nullable<string>;
+    }) => {
+      const pipeline = await renamePipelineMutation({
+        payload,
+        accessToken,
+      });
+      return Promise.resolve({
+        pipeline,
+        accessToken,
+        oldPipelineId: payload.pipelineId,
+      });
+    },
+    {
+      onSuccess: async ({ pipeline, accessToken, oldPipelineId }) => {
+        const oldPipelineName = `pipelines/${oldPipelineId}`;
+        queryClient.removeQueries(["pipelines", oldPipelineName]);
+
+        queryClient.setQueryData<Pipeline>(
+          ["pipelines", pipeline.name],
+          pipeline
+        );
+
+        queryClient.setQueryData<Pipeline[]>(["pipelines"], (old) =>
+          old
+            ? [...old.filter((e) => e.name !== oldPipelineName), pipeline]
+            : [pipeline]
+        );
+
+        // process watch state
+        const watch = await watchPipeline({
+          pipelineName: pipeline.name,
+          accessToken,
+        });
+
+        queryClient.removeQueries(["pipelines", oldPipelineName, "watch"]);
+
+        queryClient.setQueryData<PipelineWatchState>(
+          ["pipelines", pipeline.name, "watch"],
+          watch
+        );
+
+        queryClient.setQueryData<PipelinesWatchState>(
+          ["pipelines", "watch"],
+          (old) =>
+            old
+              ? {
+                  ...removeObjKey(old, oldPipelineName),
+                  [pipeline.name]: watch,
+                }
+              : { [pipeline.name]: watch }
+        );
+      },
+    }
+  );
+};

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/mutations.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/mutations.ts
@@ -36,7 +36,11 @@ export async function createPipelineMutation({
 
 export type UpdatePipelinePayload = {
   name: string;
-  description: Nullable<string>;
+  description?: string;
+  recipe?: {
+    version: string;
+    components: RawPipelineRecipeComponent[];
+  };
 };
 
 export type UpdatePipelineResponse = {
@@ -55,10 +59,7 @@ export async function updatePipelineMutation({
 
     const { data } = await client.patch<UpdatePipelineResponse>(
       `/${payload.name}`,
-      {
-        ...payload,
-        description: payload.description ?? undefined,
-      }
+      payload
     );
     return Promise.resolve(data.pipeline);
   } catch (err) {
@@ -77,6 +78,33 @@ export async function deletePipelineMutation({
     const client = createInstillAxiosClient(accessToken);
 
     await client.delete(`/${pipelineName}`);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+}
+
+export type RenamePipelinePayload = {
+  pipelineId: string;
+  newPipelineId: string;
+};
+
+export async function renamePipelineMutation({
+  payload,
+  accessToken,
+}: {
+  payload: RenamePipelinePayload;
+  accessToken: Nullable<string>;
+}) {
+  const { pipelineId, newPipelineId } = payload;
+
+  try {
+    const client = createInstillAxiosClient(accessToken);
+
+    const { data } = await client.post(`/pipelines/${pipelineId}/rename`, {
+      new_pipeline_id: newPipelineId,
+    });
+
+    return Promise.resolve(data.pipeline);
   } catch (err) {
     return Promise.reject(err);
   }

--- a/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineFormControl.tsx
+++ b/packages/toolkit/src/view/pipeline/ConfigurePipelineForm/ConfigurePipelineFormControl.tsx
@@ -93,7 +93,7 @@ export const ConfigurePipelineFormControl = (
       {
         payload: {
           name: pipeline.name,
-          description: pipelineDescription ?? null,
+          description: pipelineDescription ?? undefined,
         },
         accessToken,
       },


### PR DESCRIPTION
Because

- We need the ability to rename pipeline in pipeline-builder

This commit

- add rename pipeline mutation and react-query hook
