### PR TITLE
fix: disable the user from changing the ai-connector

### DIFF
--- a/packages/toolkit/src/view/ai/ConfigureAIForm.tsx
+++ b/packages/toolkit/src/view/ai/ConfigureAIForm.tsx
@@ -325,6 +325,7 @@ export const ConfigureAIForm = (props: ConfigureAIFormProps) => {
                         placeholder="AI's name"
                         value={field.value ?? ""}
                         autoComplete="off"
+                        disabled={true}
                       />
                     </Input.Root>
                   </Form.Control>


### PR DESCRIPTION
Because

- We should not allow user from changing the connector's name

This commit

- disable the user from changing the ai-connector
