### PR TITLE
fix(toolkit): fix type typo and export form schema in AI and blockchain forms

### DIFF
--- a/packages/toolkit/src/view/ai/ConfigureAIForm.tsx
+++ b/packages/toolkit/src/view/ai/ConfigureAIForm.tsx
@@ -31,7 +31,7 @@ import {
 import { isAxiosError } from "axios";
 import { shallow } from "zustand/shallow";
 
-const CreateAIFormSchema = z
+export const ConfigureAIFormSchema = z
   .object({
     id: z.string().min(1, { message: "ID is required" }),
     description: z.string().optional(),
@@ -135,8 +135,8 @@ export const ConfigureAIForm = (props: ConfigureAIFormProps) => {
 
   const { openModal, closeModal } = useModalStore(modalSelector, shallow);
 
-  const form = useForm<z.infer<typeof CreateAIFormSchema>>({
-    resolver: zodResolver(CreateAIFormSchema),
+  const form = useForm<z.infer<typeof ConfigureAIFormSchema>>({
+    resolver: zodResolver(ConfigureAIFormSchema),
     defaultValues: {
       ...ai,
     },
@@ -152,7 +152,7 @@ export const ConfigureAIForm = (props: ConfigureAIFormProps) => {
 
   const updateConnector = useUpdateConnector();
 
-  function onSubmit(data: z.infer<typeof CreateAIFormSchema>) {
+  function onSubmit(data: z.infer<typeof ConfigureAIFormSchema>) {
     form.trigger([
       "configuration",
       "connector_definition_name",

--- a/packages/toolkit/src/view/ai/CreateAIForm.tsx
+++ b/packages/toolkit/src/view/ai/CreateAIForm.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../lib";
 import { isAxiosError } from "axios";
 
-const CreateAIFormSchema = z
+export const CreateAIFormSchema = z
   .object({
     id: z.string().min(1, { message: "ID is required" }),
     description: z.string().optional(),

--- a/packages/toolkit/src/view/blockchan/ConfigureBlockchainForm.tsx
+++ b/packages/toolkit/src/view/blockchan/ConfigureBlockchainForm.tsx
@@ -32,7 +32,7 @@ import {
 import { DeleteResourceModal } from "../../components";
 import { shallow } from "zustand/shallow";
 
-export const ConfigureAIFormSchema = z
+export const ConfigureBlockchainFormSchema = z
   .object({
     id: z.string().min(1, { message: "ID is required" }),
     description: z.string().optional(),
@@ -120,8 +120,8 @@ export const ConfigureBlockchainForm = (
 
   const { openModal, closeModal } = useModalStore(modalSelector, shallow);
 
-  const form = useForm<z.infer<typeof ConfigureAIFormSchema>>({
-    resolver: zodResolver(ConfigureAIFormSchema),
+  const form = useForm<z.infer<typeof ConfigureBlockchainFormSchema>>({
+    resolver: zodResolver(ConfigureBlockchainFormSchema),
     defaultValues: {
       ...blockchain,
     },
@@ -137,7 +137,7 @@ export const ConfigureBlockchainForm = (
 
   const updateConnector = useUpdateConnector();
 
-  function onSubmit(data: z.infer<typeof ConfigureAIFormSchema>) {
+  function onSubmit(data: z.infer<typeof ConfigureBlockchainFormSchema>) {
     form.trigger([
       "configuration",
       "connector_definition_name",

--- a/packages/toolkit/src/view/blockchan/ConfigureBlockchainForm.tsx
+++ b/packages/toolkit/src/view/blockchan/ConfigureBlockchainForm.tsx
@@ -32,7 +32,7 @@ import {
 import { DeleteResourceModal } from "../../components";
 import { shallow } from "zustand/shallow";
 
-const CreateAIFormSchema = z
+export const ConfigureAIFormSchema = z
   .object({
     id: z.string().min(1, { message: "ID is required" }),
     description: z.string().optional(),
@@ -120,8 +120,8 @@ export const ConfigureBlockchainForm = (
 
   const { openModal, closeModal } = useModalStore(modalSelector, shallow);
 
-  const form = useForm<z.infer<typeof CreateAIFormSchema>>({
-    resolver: zodResolver(CreateAIFormSchema),
+  const form = useForm<z.infer<typeof ConfigureAIFormSchema>>({
+    resolver: zodResolver(ConfigureAIFormSchema),
     defaultValues: {
       ...blockchain,
     },
@@ -137,7 +137,7 @@ export const ConfigureBlockchainForm = (
 
   const updateConnector = useUpdateConnector();
 
-  function onSubmit(data: z.infer<typeof CreateAIFormSchema>) {
+  function onSubmit(data: z.infer<typeof ConfigureAIFormSchema>) {
     form.trigger([
       "configuration",
       "connector_definition_name",

--- a/packages/toolkit/src/view/blockchan/CreateBlockchainForm.tsx
+++ b/packages/toolkit/src/view/blockchan/CreateBlockchainForm.tsx
@@ -24,7 +24,7 @@ import {
   useCreateConnector,
 } from "../../lib";
 
-const CreateAIFormSchema = z
+export const CreateAIFormSchema = z
   .object({
     id: z.string().min(1, { message: "ID is required" }),
     description: z.string().optional(),

--- a/packages/toolkit/src/view/blockchan/CreateBlockchainForm.tsx
+++ b/packages/toolkit/src/view/blockchan/CreateBlockchainForm.tsx
@@ -24,7 +24,7 @@ import {
   useCreateConnector,
 } from "../../lib";
 
-export const CreateAIFormSchema = z
+export const CreateBlockchainFormSchema = z
   .object({
     id: z.string().min(1, { message: "ID is required" }),
     description: z.string().optional(),
@@ -86,8 +86,8 @@ export type CreateBlockchainFormProps = {
 export const CreateBlockchainForm = (props: CreateBlockchainFormProps) => {
   const { accessToken, onCreate } = props;
   const { amplitudeIsInit } = useAmplitudeCtx();
-  const form = useForm<z.infer<typeof CreateAIFormSchema>>({
-    resolver: zodResolver(CreateAIFormSchema),
+  const form = useForm<z.infer<typeof CreateBlockchainFormSchema>>({
+    resolver: zodResolver(CreateBlockchainFormSchema),
     defaultValues: {
       connector_definition_name: "connector-definitions/numbers-blockchain-nit",
       configuration: {
@@ -108,7 +108,7 @@ export const CreateBlockchainForm = (props: CreateBlockchainFormProps) => {
 
   const createConnector = useCreateConnector();
 
-  function onSubmit(data: z.infer<typeof CreateAIFormSchema>) {
+  function onSubmit(data: z.infer<typeof CreateBlockchainFormSchema>) {
     form.trigger([
       "configuration",
       "connector_definition_name",


### PR DESCRIPTION
Because

- There has typo in AI and blockchain forms

This commit

- fix type typo and export form schema in AI and blockchain forms
