### PR TITLE
fix: fix Connector configuration type

### DIFF
--- a/packages/toolkit/src/lib/vdp-sdk/connector/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/connector/types.ts
@@ -29,7 +29,7 @@ export type Connector = {
   connector_type: ConnectorType;
   task: string;
   description: string;
-  configuration: null;
+  configuration: Record<string, any> | Record<string, never>;
   state: ConnectorState;
   tombstone: boolean;
   user: string;


### PR DESCRIPTION
Because

- The Connector.configuration type is wrong

This commit

- fix Connector configuration type
