### PR TITLE
feat(toolkit): adapt backend input_only secret design

### DIFF
--- a/packages/toolkit/src/view/ai/ConfigureAIForm.tsx
+++ b/packages/toolkit/src/view/ai/ConfigureAIForm.tsx
@@ -438,6 +438,19 @@ export const ConfigureAIForm = (props: ConfigureAIFormProps) => {
                         placeholder="API Key"
                         value={field.value ?? ""}
                         autoComplete="off"
+                        onFocus={() => {
+                          if (field.value === "*****MASK*****") {
+                            field.onChange("");
+                          }
+                        }}
+                        onBlur={() => {
+                          if (
+                            field.value === "" &&
+                            ai.configuration.api_key === "*****MASK*****"
+                          ) {
+                            field.onChange("*****MASK*****");
+                          }
+                        }}
                       />
                     </Input.Root>
                   </Form.Control>

--- a/packages/toolkit/src/view/airbyte/useBuildAirbyteFields.tsx
+++ b/packages/toolkit/src/view/airbyte/useBuildAirbyteFields.tsx
@@ -299,6 +299,26 @@ export const pickComponent = (
             };
           });
         }}
+        onFocus={() => {
+          // When the user focus, we will remove the *****MASK***** value
+          // This is a temp solution.
+
+          if (setFormIsDirty) setFormIsDirty(true);
+          setValues((prev) => {
+            const value = "";
+            const configuration = prev?.configuration || {};
+            dot.setter(
+              configuration,
+              formTree.path,
+              inputType === "number" ? parseInt(value) : value
+            );
+            return {
+              ...prev,
+              configuration: configuration,
+              [formTree.path]: value,
+            };
+          });
+        }}
         readOnly={false}
       />
     );

--- a/packages/toolkit/src/view/blockchan/ConfigureBlockchainForm.tsx
+++ b/packages/toolkit/src/view/blockchan/ConfigureBlockchainForm.tsx
@@ -416,6 +416,20 @@ export const ConfigureBlockchainForm = (
                         type="password"
                         value={field.value ?? ""}
                         autoComplete="off"
+                        onFocus={() => {
+                          if (field.value === "*****MASK*****") {
+                            field.onChange("");
+                          }
+                        }}
+                        onBlur={() => {
+                          if (
+                            field.value === "" &&
+                            blockchain.configuration.api_key ===
+                              "*****MASK*****"
+                          ) {
+                            field.onChange("*****MASK*****");
+                          }
+                        }}
                       />
                     </Input.Root>
                   </Form.Control>


### PR DESCRIPTION
Because

- After this release all the secret field will be input_only and its response will become "*****MASK*****"
- We fill in "" into airbyte secret fields when user focus it. 
- We fill in "" into AI, Blockchain form when user focus it and fill "*****MASK*****" when user blur the input if the connector had been created.

This commit

- adapt backend input_only secret design
