### PR TITLE
fix(toolkit): fix Airbyte input only field wrongly access variable

### DIFF
--- a/packages/toolkit/src/view/airbyte/useBuildAirbyteFields.tsx
+++ b/packages/toolkit/src/view/airbyte/useBuildAirbyteFields.tsx
@@ -307,11 +307,7 @@ export const pickComponent = (
           setValues((prev) => {
             const value = "";
             const configuration = prev?.configuration || {};
-            dot.setter(
-              configuration,
-              formTree.path,
-              inputType === "number" ? parseInt(value) : value
-            );
+            dot.setter(configuration, formTree.path, value);
             return {
               ...prev,
               configuration: configuration,


### PR DESCRIPTION
Because

- Airbyte input only field wrongly access variable

This commit

- fix Airbyte input only field wrongly access variable
