### PR TITLE
fix: fix typo at ConfigureBlockchainForm

### DIFF
--- a/packages/toolkit/src/view/blockchan/ConfigureBlockchainForm.tsx
+++ b/packages/toolkit/src/view/blockchan/ConfigureBlockchainForm.tsx
@@ -430,7 +430,7 @@ export const ConfigureBlockchainForm = (
                         onBlur={() => {
                           if (
                             field.value === "" &&
-                            blockchain.configuration.api_key ===
+                            blockchain.configuration.capture_token ===
                               "*****MASK*****"
                           ) {
                             field.onChange("*****MASK*****");


### PR DESCRIPTION
Because

- the access path of blockchain configuration has typo

This commit

- fix typo at ConfigureBlockchainForm