### PR TITLE
fix: make blockchain flow be consistent as other connector

### DIFF
--- a/packages/toolkit/src/view/blockchan/CreateBlockchainForm.tsx
+++ b/packages/toolkit/src/view/blockchan/CreateBlockchainForm.tsx
@@ -71,7 +71,6 @@ export const CreateBlockchainForm = (props: CreateBlockchainFormProps) => {
   const form = useForm<z.infer<typeof CreateBlockchainFormSchema>>({
     resolver: zodResolver(CreateBlockchainFormSchema),
     defaultValues: {
-      connector_definition_name: "connector-definitions/blockchain-numbers",
       configuration: {
         metadata_texts: false,
         metadata_structured_data: false,


### PR DESCRIPTION
Because

- form need to be consistent across the app

This commit

- make blockchain flow be consistent as other connector
