### PR TITLE
fix: fix blockchain/create id field disabled issue

### DIFF
--- a/packages/toolkit/src/view/blockchan/CreateBlockchainForm.tsx
+++ b/packages/toolkit/src/view/blockchan/CreateBlockchainForm.tsx
@@ -167,7 +167,6 @@ export const CreateBlockchainForm = (props: CreateBlockchainFormProps) => {
                         {...field}
                         type="text"
                         value={field.value ?? ""}
-                        disabled={true}
                         autoComplete="off"
                       />
                     </Input.Root>


### PR DESCRIPTION
Because

- fix blockchain/create id field is wrongly disabled

This commit

- fix blockchain/create id field disabled issue
