### PR TITLE
fix(toolkit): fix pipeline builder ondelete issue

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/flow/Flow.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/flow/Flow.tsx
@@ -102,6 +102,7 @@ export const Flow = forwardRef<HTMLDivElement, FlowProps>((props, ref) => {
             onNodesDelete={(nodes) => {
               if (nodes.some((node) => node.id === selectedNode?.id)) {
                 setSelectedNode(null);
+                updateResourceFormIsDirty(() => false);
               }
             }}
             onNodesChange={(event) => {


### PR DESCRIPTION
Because

- pipeline builder ondelete has issue when the form is dirty

This commit

-  fix pipeline builder ondelete issue
