### PR TITLE
fix(pipeline-builder): fix pipeline-builder's node name overflow text issue

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.59.2",
+  "version": "0.59.3-rc.0",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/nodes/CustomNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/nodes/CustomNode.tsx
@@ -78,10 +78,10 @@ Root.displayName = "CustomNodeRoot";
 
 const NameRow = (props: { name: string; icon: React.ReactElement }) => {
   return (
-    <div className="flex h-[56px] rounded-tl-[12px] rounded-tr-[12px] bg-semantic-bg-secondary p-4 transition-colors duration-500 group-hover:bg-semantic-bg-line">
+    <div className="flex rounded-tl-[12px] rounded-tr-[12px] bg-semantic-bg-secondary p-4 transition-colors duration-500 group-hover:bg-semantic-bg-line">
       <div className="flex w-full flex-row space-x-2">
         {props.icon}
-        <p className="text-semantic-fg-primary product-body-text-2-semibold">
+        <p className="text-semantic-fg-primary line-clamp-2 product-body-text-2-semibold">
           {props.name}
         </p>
       </div>


### PR DESCRIPTION
Because

- pipeline-builder's node name is overflow

This commit

- fix pipeline-builder's node name overflow text issue
