### PR TITLE
fix: replace empty icon with fill icon in activate/deactivate button

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.59.3-rc.0",
+  "version": "0.59.2",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/ai/ConfigureAIForm.tsx
+++ b/packages/toolkit/src/view/ai/ConfigureAIForm.tsx
@@ -831,7 +831,7 @@ export const ConfigureAIForm = (props: ConfigureAIFormProps) => {
                   </svg>
                 ) : ai.watchState === "STATE_CONNECTED" ||
                   ai.watchState === "STATE_ERROR" ? (
-                  <Icons.Stop className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+                  <Icons.Stop className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
                 ) : (
                   <Icons.Play className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
                 )}

--- a/packages/toolkit/src/view/blockchan/ConfigureBlockchainForm.tsx
+++ b/packages/toolkit/src/view/blockchan/ConfigureBlockchainForm.tsx
@@ -732,9 +732,9 @@ export const ConfigureBlockchainForm = (
                   </svg>
                 ) : blockchain.watchState === "STATE_CONNECTED" ||
                   blockchain.watchState === "STATE_ERROR" ? (
-                  <Icons.Stop className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+                  <Icons.Stop className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
                 ) : (
-                  <Icons.Play className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+                  <Icons.Play className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
                 )}
               </Button>
               <button

--- a/packages/toolkit/src/view/destination/ConfigureDestinationForm.tsx
+++ b/packages/toolkit/src/view/destination/ConfigureDestinationForm.tsx
@@ -620,9 +620,9 @@ export const ConfigureDestinationForm = (
                 </svg>
               ) : destination.watchState === "STATE_CONNECTED" ||
                 destination.watchState === "STATE_ERROR" ? (
-                <Icons.Stop className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+                <Icons.Stop className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
               ) : (
-                <Icons.Play className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+                <Icons.Play className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
               )}
             </Button>
             <SolidButton

--- a/packages/toolkit/src/view/pipeline-builder/flow/FlowControl.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/flow/FlowControl.tsx
@@ -320,12 +320,12 @@ export const FlowControl = (props: FlowControlProps) => {
           pipelineWatchState.data.state === "STATE_ERROR" ? (
             <>
               <span>Deactivate</span>
-              <Icons.Stop className="h-5 w-5 stroke-semantic-bg-primary group-disabled:stroke-semantic-fg-disabled" />
+              <Icons.Stop className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
             </>
           ) : (
             <>
               <span>Activate</span>
-              <Icons.Play className="h-5 w-5 stroke-semantic-bg-primary group-disabled:stroke-semantic-fg-disabled" />
+              <Icons.Play className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
             </>
           )
         ) : (

--- a/packages/toolkit/src/view/pipeline-builder/right-panel/AIForm.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/right-panel/AIForm.tsx
@@ -957,9 +957,9 @@ export const AIForm = (props: AIFormProps) => {
               </svg>
             ) : ai.watchState === "STATE_CONNECTED" ||
               ai.watchState === "STATE_ERROR" ? (
-              <Icons.Stop className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+              <Icons.Stop className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
             ) : (
-              <Icons.Play className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+              <Icons.Play className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
             )}
           </Button>
           <Button

--- a/packages/toolkit/src/view/pipeline-builder/right-panel/BlockchainForm.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/right-panel/BlockchainForm.tsx
@@ -810,9 +810,9 @@ export const BlockchainForm = (props: BlockchainFormProps) => {
               </svg>
             ) : blockchain.watchState === "STATE_CONNECTED" ||
               blockchain.watchState === "STATE_ERROR" ? (
-              <Icons.Stop className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+              <Icons.Stop className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
             ) : (
-              <Icons.Play className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+              <Icons.Play className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
             )}
           </Button>
           <Button

--- a/packages/toolkit/src/view/pipeline-builder/right-panel/DestinationForm.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/right-panel/DestinationForm.tsx
@@ -785,9 +785,9 @@ export const DestinationForm = (props: DestinationFormProps) => {
               </svg>
             ) : destination.watchState === "STATE_CONNECTED" ||
               destination.watchState === "STATE_ERROR" ? (
-              <Icons.Stop className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+              <Icons.Stop className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
             ) : (
-              <Icons.Play className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+              <Icons.Play className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
             )}
           </Button>
           <Button

--- a/packages/toolkit/src/view/pipeline-builder/right-panel/SourceForm.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/right-panel/SourceForm.tsx
@@ -378,9 +378,9 @@ export const SourceForm = (props: SourceFormProps) => {
                 </svg>
               ) : source.watchState === "STATE_CONNECTED" ||
                 source.watchState === "STATE_ERROR" ? (
-                <Icons.Stop className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+                <Icons.Stop className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
               ) : (
-                <Icons.Play className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+                <Icons.Play className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
               )}
             </Button>
             <Button

--- a/packages/toolkit/src/view/source/ConfigureSourceForm/ConfigureSourceControl.tsx
+++ b/packages/toolkit/src/view/source/ConfigureSourceForm/ConfigureSourceControl.tsx
@@ -219,9 +219,9 @@ export const ConfigureSourceControl = (props: ConfigureSourceControlProps) => {
                 : "Connect"}
               {source.watchState === "STATE_CONNECTED" ||
               source.watchState === "STATE_ERROR" ? (
-                <Icons.Stop className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+                <Icons.Stop className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
               ) : (
-                <Icons.Play className="h-4 w-4 stroke-semantic-fg-on-default group-disabled:stroke-semantic-fg-disabled" />
+                <Icons.Play className="h-4 w-4 fill-semantic-fg-on-default stroke-semantic-fg-on-default group-disabled:fill-semantic-fg-disabled group-disabled:stroke-semantic-fg-disabled" />
               )}
             </Button>
             <SolidButton


### PR DESCRIPTION
Because

- deactivate empty path icon looks like checkbox

This commit

- replace empty icon with fill icon in activate/deactivate button
