### PR TITLE
fix: fix save pipeline action not correctly early return

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/flow/FlowControl.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/flow/FlowControl.tsx
@@ -263,6 +263,8 @@ export const FlowControl = (props: FlowControlProps) => {
           });
         }
       }
+
+      return;
     }
 
     const payload: CreatePipelinePayload = {


### PR DESCRIPTION
Because

- save pipeline action not correctly early return

This commit

- fix save pipeline action not correctly early return