### PR TITLE
feat: example for asChild in components

### DIFF
--- a/packages/design-system/src/new-ui/Button/Button.stories.tsx
+++ b/packages/design-system/src/new-ui/Button/Button.stories.tsx
@@ -80,7 +80,15 @@ export const PrimaryWithIcon: Story = {
   render: () => (
     <Button className="gap-x-2" variant="primary" size="lg">
       I am a button
-      <Icons.Play className="w-5 h-5 stroke-semantic-bg-primary" />
+      <Icons.Play className="h-5 w-5 stroke-semantic-bg-primary" />
+    </Button>
+  ),
+};
+
+export const PrimaryWithAsChild: Story = {
+  render: () => (
+    <Button className="gap-x-2" variant="primary" size="lg" asChild>
+      <a href="https://www.instill.tech/">Instill AI</a>
     </Button>
   ),
 };

--- a/packages/design-system/src/new-ui/LinkButton/LinkButton.stories.tsx
+++ b/packages/design-system/src/new-ui/LinkButton/LinkButton.stories.tsx
@@ -42,3 +42,11 @@ export const White: Story = {
     </div>
   ),
 };
+
+export const PrimaryWithAsChild: Story = {
+  render: () => (
+    <LinkButton className="gap-x-2" variant="primary" size="lg" asChild>
+      <a href="https://www.instill.tech/">Instill AI</a>
+    </LinkButton>
+  ),
+};

--- a/packages/design-system/src/new-ui/TagButton/TagButton.stories.tsx
+++ b/packages/design-system/src/new-ui/TagButton/TagButton.stories.tsx
@@ -12,3 +12,11 @@ type Story = StoryObj<typeof TagButton>;
 export const Dafault: Story = {
   render: () => <TagButton>Label</TagButton>,
 };
+
+export const PrimaryWithAsChild: Story = {
+  render: () => (
+    <TagButton className="gap-x-2" variant="default" size="lg" asChild>
+      <a href="https://www.instill.tech/">Instill AI</a>
+    </TagButton>
+  ),
+};


### PR DESCRIPTION
Because

- we need to example for asChild in components in stories

This commit

- example for asChild in components
