### PR TITLE
chore(toolkit): add sortByTriggerTime for pipeline triggertable

### DIFF
--- a/packages/toolkit/src/lib/dashboard/index.ts
+++ b/packages/toolkit/src/lib/dashboard/index.ts
@@ -12,4 +12,5 @@ export * from "./getTimeInRFC3339Format";
 export * from "./parseTriggerStatusLabel";
 export * from "./options";
 export * from "./orderCountsByTriggerTime";
+export * from "./sortByTriggerTime";
 export * from "./xAxisRange";

--- a/packages/toolkit/src/lib/dashboard/sortByTriggerTime.ts
+++ b/packages/toolkit/src/lib/dashboard/sortByTriggerTime.ts
@@ -1,0 +1,10 @@
+import { PipelineTriggerRecord } from "../vdp-sdk";
+
+export function sortByTriggerTime(
+  data: PipelineTriggerRecord[]
+): PipelineTriggerRecord[] {
+  return data.sort(
+    (a, b) =>
+      new Date(b.trigger_time).getTime() - new Date(a.trigger_time).getTime()
+  );
+}


### PR DESCRIPTION
Because

- add sortByTriggerTime for pipeline triggertable

This commit

- add sortByTriggerTime for pipeline triggertable
