### PR TITLE
fix: fix snippet typo

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/FlowControl.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/FlowControl.tsx
@@ -291,10 +291,7 @@ export const FlowControl = (props: FlowControlProps) => {
         : triggerPipelineSnippets.core;
 
     snippet = snippet
-      .replace(
-        /\{vdp-pipeline-base-url\}/g,
-        env("NEXT_PUBLIC_VDP_API_GATEWAY_URL")
-      )
+      .replace(/\{vdp-pipeline-base-url\}/g, env("NEXT_PUBLIC_API_GATEWAY_URL"))
       .replace(
         /\{pipeline-name\}/g,
         `${user.data.name}/pipelines/${pipelineId}`


### PR DESCRIPTION
Because

- trigger pipeline snippet has typo

This commit

- fix snippet typo
